### PR TITLE
Check parser as done and new language pkg todos.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 graphql-go [![Build Status](https://travis-ci.org/chris-ramon/graphql-go.svg)](https://travis-ci.org/chris-ramon/graphql-go) [![GoDoc](https://godoc.org/graphql.co/graphql?status.svg)](https://godoc.org/github.com/chris-ramon/graphql-go)
 =====
-An *work in progress* implementation of GraphQL for Go
+An *work in progress* implementation of GraphQL for Go.
 
 #### Roadmap
 - [x] Lexer
-- [ ] Parser
+- [x] Parser
+- [ ] Schema Parser
+- [ ] Printer
+- [ ] Schema Printer
+- [ ] Visitor
 - [ ] Executor
 - [ ] Basic usage
 - [ ] Relay/React example


### PR DESCRIPTION
I think we are good checking parser as done, since parser tests 
from `graphql-js/src/language/__tests__/parser.js` are all passing
thanks to the enormous effort and work from @sogko :star2:


This pr adds to roadmap four todos related to the `language` pkg
todos that matches the test files from `graphql-js/src/language/__tests__`

 