### PR TITLE
Improves to NewSource.

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -18,7 +18,10 @@ type GraphqlParams struct {
 }
 
 func Graphql(p GraphqlParams, resultChannel chan *types.GraphQLResult) {
-	source := source.NewSource(p.RequestString, "GraphQL request")
+	source := source.NewSource(&source.Source{
+		Body: p.RequestString,
+		Name: "GraphQL request",
+	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {
 		result := types.GraphQLResult{

--- a/language/lexer/lexer_test.go
+++ b/language/lexer/lexer_test.go
@@ -12,6 +12,10 @@ type Test struct {
 	Expected interface{}
 }
 
+func createSource(body string) *source.Source {
+	return source.NewSource(&source.Source{Body: body})
+}
+
 func TestSkipsWhiteSpace(t *testing.T) {
 	tests := []Test{
 		Test{
@@ -66,8 +70,7 @@ func TestErrorsRespectWhitespace(t *testing.T) {
     ?
 
 `
-	source := source.NewSource(body, "")
-	_, err := Lex(source)(0)
+	_, err := Lex(createSource(body))(0)
 	expected := "Syntax Error GraphQL (3:5) Unexpected character \"?\".\n\n2: \n3:     ?\n       ^\n4: \n"
 	if err == nil {
 		t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", expected, err)
@@ -249,7 +252,7 @@ func TestLexReportsUsefulStringErrors(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, err := Lex(source.NewSource(test.Body, ""))(0)
+		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
 			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
@@ -407,7 +410,7 @@ func TestLexesNumbers(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		token, err := Lex(source.NewSource(test.Body, ""))(0)
+		token, err := Lex(createSource(test.Body))(0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v, test: %s", err, test)
 		}
@@ -485,7 +488,7 @@ func TestLexReportsUsefulNumbeErrors(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, err := Lex(source.NewSource(test.Body, ""))(0)
+		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
 			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
@@ -616,7 +619,7 @@ func TestLexesPunctuation(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		token, err := Lex(source.NewSource(test.Body, ""))(0)
+		token, err := Lex(createSource(test.Body))(0)
 		if err != nil {
 			t.Fatalf("unexpected error :%v, test: %v", err, test)
 		}
@@ -654,7 +657,7 @@ func TestLexReportsUsefulUnknownCharacterError(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		_, err := Lex(source.NewSource(test.Body, ""))(0)
+		_, err := Lex(createSource(test.Body))(0)
 		if err == nil {
 			t.Fatalf("unexpected nil error\nexpected:\n%v\n\ngot:\n%v", test.Expected, err)
 		}
@@ -666,7 +669,7 @@ func TestLexReportsUsefulUnknownCharacterError(t *testing.T) {
 
 func TestLexRerportsUsefulInformationForDashesInNames(t *testing.T) {
 	q := "a-b"
-	lexer := Lex(source.NewSource(q, ""))
+	lexer := Lex(createSource(q))
 	firstToken, err := lexer(0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/language/parser/parser.go
+++ b/language/parser/parser.go
@@ -35,8 +35,8 @@ func Parse(p ParseParams) (*ast.Document, error) {
 	case *source.Source:
 		sourceObj = p.Source.(*source.Source)
 	default:
-		s, _ := p.Source.(string)
-		sourceObj = source.NewSource(s, "")
+		body, _ := p.Source.(string)
+		sourceObj = source.NewSource(&source.Source{Body: body})
 	}
 	parser, err := makeParser(sourceObj, p.Options)
 	if err != nil {
@@ -57,8 +57,8 @@ func parseValue(p ParseParams) (ast.Value, error) {
 	case *source.Source:
 		sourceObj = p.Source.(*source.Source)
 	default:
-		s, _ := p.Source.(string)
-		sourceObj = source.NewSource(s, "")
+		body, _ := p.Source.(string)
+		sourceObj = source.NewSource(&source.Source{Body: body})
 	}
 	parser, err := makeParser(sourceObj, p.Options)
 	if err != nil {

--- a/language/parser/parser_test.go
+++ b/language/parser/parser_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"fmt"
+	"io/ioutil"
+	"strings"
+
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/language/ast"
 	"github.com/chris-ramon/graphql-go/language/location"
 	"github.com/chris-ramon/graphql-go/language/source"
-	"io/ioutil"
-	"strings"
 )
 
 func TestAcceptsOptionToNotIncludeSource(t *testing.T) {
@@ -124,7 +125,7 @@ fragment MissingOn Type
 
 func TestParseProvidesUsefulErrorsWhenUsingSource(t *testing.T) {
 	test := errorMessageTest{
-		source.NewSource("query", "MyQuery.graphql"),
+		source.NewSource(&source.Source{Body: "query", Name: "MyQuery.graphql"}),
 		`Syntax Error MyQuery.graphql (1:6) Expected Name, found EOF`,
 		false,
 	}
@@ -240,14 +241,14 @@ func TestParsesExperimentalSubscriptionFeature(t *testing.T) {
 }
 
 func TestParseCreatesAst(t *testing.T) {
-	source := source.NewSource(`{
+	body := `{
   node(id: 4) {
     id,
     name
   }
 }
-`, "")
-
+`
+	source := source.NewSource(&source.Source{Body: body})
 	document, err := Parse(
 		ParseParams{
 			Source: source,

--- a/language/source/source.go
+++ b/language/source/source.go
@@ -1,16 +1,20 @@
 package source
 
+const (
+	name = "GraphQL"
+)
+
 type Source struct {
 	Body string
 	Name string
 }
 
-func NewSource(body, name string) *Source {
-	if name == "" {
-		name = "GraphQL"
+func NewSource(s *Source) *Source {
+	if s == nil {
+		s = &Source{Name: name}
 	}
-	return &Source{
-		Body: body,
-		Name: name,
+	if s.Name == "" {
+		s.Name = name
 	}
+	return s
 }


### PR DESCRIPTION
This pr updates source.NewSource in order to match the new struct instance pattern we are using so far and set `GraphQL` as default `Source.Name`