### PR TITLE
Makes executor/nonnull tests pass.

### DIFF
--- a/errors/sortutil.go
+++ b/errors/sortutil.go
@@ -1,0 +1,30 @@
+package graphqlerrors
+
+import "bytes"
+
+type GQLFormattedErrorSlice []GraphQLFormattedError
+
+func (errs GQLFormattedErrorSlice) Len() int {
+	return len(errs)
+}
+
+func (errs GQLFormattedErrorSlice) Swap(i, j int) {
+	errs[i], errs[j] = errs[j], errs[i]
+}
+
+func (errs GQLFormattedErrorSlice) Less(i, j int) bool {
+	mCompare := bytes.Compare([]byte(errs[i].Message), []byte(errs[j].Message))
+	lesserLine := errs[i].Locations[0].Line < errs[j].Locations[0].Line
+	eqLine := errs[i].Locations[0].Line == errs[j].Locations[0].Line
+	lesserColumn := errs[i].Locations[0].Column < errs[j].Locations[0].Column
+	if mCompare < 0 {
+		return true
+	}
+	if mCompare == 0 && lesserLine {
+		return true
+	}
+	if mCompare == 0 && eqLine && lesserColumn {
+		return true
+	}
+	return false
+}

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -267,8 +267,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNulableFieldThatThrowsSynchronously(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldThatThrowsSynchronously(t *testing.T) {
 	doc := `
       query Q {
         promiseNest {

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -559,25 +559,25 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 		},
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 8, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 19, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 30, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 41, Column: 19},
 				},
@@ -600,8 +600,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -227,8 +227,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldThatThrowsInAPromise(t *testing.T) {
 	doc := `
       query Q {
         nest {

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -150,7 +150,6 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 	}
 }
 func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
 	doc := `
       query Q {
         promise

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -998,8 +998,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -1,13 +1,15 @@
 package executor_test
 
 import (
+	"reflect"
+	"sort"
+	"testing"
+
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/executor"
 	"github.com/chris-ramon/graphql-go/language/location"
 	"github.com/chris-ramon/graphql-go/testutil"
 	"github.com/chris-ramon/graphql-go/types"
-	"reflect"
-	"testing"
 )
 
 var syncError = "sync"
@@ -497,8 +499,9 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -307,8 +307,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNulableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldThatThrowsInAPromise(t *testing.T) {
 	doc := `
       query Q {
         promiseNest {


### PR DESCRIPTION
#### Details
Makes test's from `executor/nonull_test.go` pass, the ones being skipped using `t.Skipf`.

#### Task List
- [x] `NullsAComplexTreeOfNullableFieldsThatThrow`
- [x] `NullsANullableFieldThatThrowsInAPromise`
- [x] `NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldThatThrowsInAPromise`
- [x] `NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldThatThrowsSynchronously`
- [x] `NullsAnObjectReturnedInAPromiseThatContainsANonNulableFieldThatThrowsInAPromise`
- [x] `NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfFieldsThatAreNonNull`
- [x] `NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOfFieldsThatAreNonNull`