### PR TITLE
Removes `github.com/deckarep/golang-set` dependency.

### DIFF
--- a/errors/sortutil.go
+++ b/errors/sortutil.go
@@ -1,0 +1,30 @@
+package graphqlerrors
+
+import "bytes"
+
+type GQLFormattedErrorSlice []GraphQLFormattedError
+
+func (errs GQLFormattedErrorSlice) Len() int {
+	return len(errs)
+}
+
+func (errs GQLFormattedErrorSlice) Swap(i, j int) {
+	errs[i], errs[j] = errs[j], errs[i]
+}
+
+func (errs GQLFormattedErrorSlice) Less(i, j int) bool {
+	mCompare := bytes.Compare([]byte(errs[i].Message), []byte(errs[j].Message))
+	lesserLine := errs[i].Locations[0].Line < errs[j].Locations[0].Line
+	eqLine := errs[i].Locations[0].Line == errs[j].Locations[0].Line
+	lesserColumn := errs[i].Locations[0].Column < errs[j].Locations[0].Column
+	if mCompare < 0 {
+		return true
+	}
+	if mCompare == 0 && lesserLine {
+		return true
+	}
+	if mCompare == 0 && eqLine && lesserColumn {
+		return true
+	}
+	return false
+}

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -267,8 +267,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNulableFieldThatThrowsSynchronously(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldThatThrowsSynchronously(t *testing.T) {
 	doc := `
       query Q {
         promiseNest {

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -559,25 +559,25 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 		},
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 8, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullSync.`,
+				Message: nonNullSyncError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 19, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 30, Column: 19},
 				},
 			},
 			graphqlerrors.GraphQLFormattedError{
-				Message: `Cannot return null for non-nullable field DataType.nonNullPromise.`,
+				Message: nonNullPromiseError,
 				Locations: []location.SourceLocation{
 					location.SourceLocation{Line: 41, Column: 19},
 				},
@@ -600,8 +600,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -227,8 +227,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldThatThrowsInAPromise(t *testing.T) {
 	doc := `
       query Q {
         nest {

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -634,7 +634,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNull(t *testing.T) {
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
@@ -665,7 +665,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *te
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }
@@ -895,7 +895,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatReturnNull(t *testing.T) {
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -150,7 +150,6 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
 	}
 }
 func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
 	doc := `
       query Q {
         promise

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -998,8 +998,9 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -1,13 +1,15 @@
 package executor_test
 
 import (
+	"reflect"
+	"sort"
+	"testing"
+
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/executor"
 	"github.com/chris-ramon/graphql-go/language/location"
 	"github.com/chris-ramon/graphql-go/testutil"
 	"github.com/chris-ramon/graphql-go/types"
-	"reflect"
-	"testing"
 )
 
 var syncError = "sync"
@@ -497,8 +499,9 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
 	if !reflect.DeepEqual(expected.Data, result.Data) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Data, result.Data))
 	}
-	t.Skipf("Testing equality for slice of errors in results")
-	if !testutil.EqualSet(expected.Errors, result.Errors) {
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(expected.Errors))
+	sort.Sort(graphqlerrors.GQLFormattedErrorSlice(result.Errors))
+	if !reflect.DeepEqual(expected.Errors, result.Errors) {
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected.Errors, result.Errors))
 	}
 }

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -307,8 +307,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
 		t.Fatalf("Unexpected result, Diff: %v", testutil.Diff(expected, result))
 	}
 }
-func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNulableFieldThatThrowsInAPromise(t *testing.T) {
-	t.Skipf("Promises not implemented")
+func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldThatThrowsInAPromise(t *testing.T) {
 	doc := `
       query Q {
         promiseNest {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -367,33 +367,6 @@ func Diff(a, b interface{}) []string {
 	return pretty.Diff(a, b)
 }
 
-// TODO: EqualSet, commenting by now
-// perhaps not need to depend on
-// github.com/deckarep/golang-set
-//func EqualSet(a, b interface{}) bool {
-
-//aa := []interface{}{}
-//bb := []interface{}{}
-
-//aVal := reflect.ValueOf(a)
-//bVal := reflect.ValueOf(b)
-//if aVal.Type().Kind() == reflect.Slice {
-//for i := 0; i < aVal.Len(); i++ {
-//val := aVal.Index(i).Interface()
-//aa = append(aa, &val)
-//}
-//}
-//if bVal.Type().Kind() == reflect.Slice {
-//for i := 0; i < bVal.Len(); i++ {
-//val := bVal.Index(i).Interface()
-//bb = append(bb, &val)
-//}
-//}
-//xx := mapset.NewSetFromSlice(aa)
-//yy := mapset.NewSetFromSlice(bb)
-//return xx.Equal(yy)
-//}
-
 func ASTToJSON(t *testing.T, a ast.Node) interface{} {
 	b, err := json.Marshal(a)
 	if err != nil {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -2,15 +2,14 @@ package testutil
 
 import (
 	"encoding/json"
+	"strconv"
+	"testing"
+
 	"github.com/chris-ramon/graphql-go/executor"
 	"github.com/chris-ramon/graphql-go/language/ast"
 	"github.com/chris-ramon/graphql-go/language/parser"
 	"github.com/chris-ramon/graphql-go/types"
-	"github.com/deckarep/golang-set"
 	"github.com/kr/pretty"
-	"reflect"
-	"strconv"
-	"testing"
 )
 
 var (
@@ -368,30 +367,32 @@ func Diff(a, b interface{}) []string {
 	return pretty.Diff(a, b)
 }
 
-// TODO: EqualSet
-func EqualSet(a, b interface{}) bool {
+// TODO: EqualSet, commenting by now
+// perhaps not need to depend on
+// github.com/deckarep/golang-set
+//func EqualSet(a, b interface{}) bool {
 
-	aa := []interface{}{}
-	bb := []interface{}{}
+//aa := []interface{}{}
+//bb := []interface{}{}
 
-	aVal := reflect.ValueOf(a)
-	bVal := reflect.ValueOf(b)
-	if aVal.Type().Kind() == reflect.Slice {
-		for i := 0; i < aVal.Len(); i++ {
-			val := aVal.Index(i).Interface()
-			aa = append(aa, &val)
-		}
-	}
-	if bVal.Type().Kind() == reflect.Slice {
-		for i := 0; i < bVal.Len(); i++ {
-			val := bVal.Index(i).Interface()
-			bb = append(bb, &val)
-		}
-	}
-	xx := mapset.NewSetFromSlice(aa)
-	yy := mapset.NewSetFromSlice(bb)
-	return xx.Equal(yy)
-}
+//aVal := reflect.ValueOf(a)
+//bVal := reflect.ValueOf(b)
+//if aVal.Type().Kind() == reflect.Slice {
+//for i := 0; i < aVal.Len(); i++ {
+//val := aVal.Index(i).Interface()
+//aa = append(aa, &val)
+//}
+//}
+//if bVal.Type().Kind() == reflect.Slice {
+//for i := 0; i < bVal.Len(); i++ {
+//val := bVal.Index(i).Interface()
+//bb = append(bb, &val)
+//}
+//}
+//xx := mapset.NewSetFromSlice(aa)
+//yy := mapset.NewSetFromSlice(bb)
+//return xx.Equal(yy)
+//}
 
 func ASTToJSON(t *testing.T, a ast.Node) interface{} {
 	b, err := json.Marshal(a)


### PR DESCRIPTION
Built on top of #13: 

#### Details
- Removes `github.com/deckarep/golang-set` dependency.
- Was being use within `executor/nonnull_test.go` through `testutil.EqualSet`, but we can use instead `reflect.Equal`, sorting slices before comparing equality is a simple solution instead of having this dep.

