### PR TITLE
Renames package `types` to `gqltypes`

### DIFF
--- a/executor/abstract_test.go
+++ b/executor/abstract_test.go
@@ -1,13 +1,14 @@
 package executor_test
 
 import (
-	"github.com/chris-ramon/graphql-go"
-	"github.com/chris-ramon/graphql-go/errors"
-	"github.com/chris-ramon/graphql-go/language/location"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go"
+	"github.com/chris-ramon/graphql-go/errors"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/language/location"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
 type testDog struct {
@@ -26,38 +27,38 @@ type testHuman struct {
 
 func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 
-	petType := types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+	petType := gqltypes.NewGraphQLInterfaceType(gqltypes.GraphQLInterfaceTypeConfig{
 		Name: "Pet",
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
 		},
 	})
 
 	// ie declare that Dog belongs to Pet interface
-	_ = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	_ = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Dog",
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			petType,
 		},
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
 					return nil
 				},
 			},
-			"woofs": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"woofs": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -67,28 +68,28 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		},
 	})
 	// ie declare that Cat belongs to Pet interface
-	_ = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	_ = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Cat",
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			petType,
 		},
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
 					return nil
 				},
 			},
-			"meows": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"meows": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -97,13 +98,13 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 			},
 		},
 	})
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"pets": &types.GraphQLFieldConfig{
-					Type: types.NewGraphQLList(petType),
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"pets": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.NewGraphQLList(petType),
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -129,7 +130,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
 				map[string]interface{}{
@@ -145,7 +146,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 		Errors: nil,
 	}
 
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 
 	go gql.Graphql(gql.GraphqlParams{
 		Schema:        schema,
@@ -162,25 +163,25 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForInterface(t *testing.T) {
 
 func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 
-	dogType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	dogType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Dog",
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
 					return nil
 				},
 			},
-			"woofs": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"woofs": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -189,25 +190,25 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			},
 		},
 	})
-	catType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	catType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Cat",
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
 					return nil
 				},
 			},
-			"meows": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"meows": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -217,12 +218,12 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		},
 	})
 	// ie declare Pet has Dot and Cat object types
-	petType := types.NewGraphQLUnionType(types.GraphQLUnionTypeConfig{
+	petType := gqltypes.NewGraphQLUnionType(gqltypes.GraphQLUnionTypeConfig{
 		Name: "Pet",
-		Types: []*types.GraphQLObjectType{
+		Types: []*gqltypes.GraphQLObjectType{
 			dogType, catType,
 		},
-		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+		ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 			if _, ok := value.(*testCat); ok {
 				return catType
 			}
@@ -232,13 +233,13 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 			return nil
 		},
 	})
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"pets": &types.GraphQLFieldConfig{
-					Type: types.NewGraphQLList(petType),
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"pets": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.NewGraphQLList(petType),
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -264,7 +265,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
 				map[string]interface{}{
@@ -280,7 +281,7 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 		Errors: nil,
 	}
 
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 
 	go gql.Graphql(gql.GraphqlParams{
 		Schema:        schema,
@@ -298,17 +299,17 @@ func TestIsTypeOfUsedToResolveRuntimeTypeForUnion(t *testing.T) {
 
 func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 
-	var dogType *types.GraphQLObjectType
-	var catType *types.GraphQLObjectType
-	var humanType *types.GraphQLObjectType
-	petType := types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+	var dogType *gqltypes.GraphQLObjectType
+	var catType *gqltypes.GraphQLObjectType
+	var humanType *gqltypes.GraphQLObjectType
+	petType := gqltypes.NewGraphQLInterfaceType(gqltypes.GraphQLInterfaceTypeConfig{
 		Name: "Pet",
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
 		},
-		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+		ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 			if _, ok := value.(*testCat); ok {
 				return catType
 			}
@@ -322,12 +323,12 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		},
 	})
 
-	humanType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	humanType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Human",
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
 						return human.Name
 					}
@@ -336,28 +337,28 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	dogType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	dogType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Dog",
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			petType,
 		},
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
 					return nil
 				},
 			},
-			"woofs": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"woofs": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -366,28 +367,28 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	catType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	catType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Cat",
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			petType,
 		},
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
 					return nil
 				},
 			},
-			"meows": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"meows": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -396,13 +397,13 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"pets": &types.GraphQLFieldConfig{
-					Type: types.NewGraphQLList(petType),
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"pets": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.NewGraphQLList(petType),
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -429,7 +430,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
 				map[string]interface{}{
@@ -451,7 +452,7 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 
 	go gql.Graphql(gql.GraphqlParams{
 		Schema:        schema,
@@ -468,12 +469,12 @@ func TestResolveTypeOnInterfaceYieldsUsefulError(t *testing.T) {
 
 func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 
-	humanType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	humanType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Human",
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(*testHuman); ok {
 						return human.Name
 					}
@@ -482,25 +483,25 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	dogType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	dogType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Dog",
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testDog)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Name
 					}
 					return nil
 				},
 			},
-			"woofs": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"woofs": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if dog, ok := p.Source.(*testDog); ok {
 						return dog.Woofs
 					}
@@ -509,25 +510,25 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	catType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	catType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Cat",
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			_, ok := value.(*testCat)
 			return ok
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Name
 					}
 					return nil
 				},
 			},
-			"meows": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"meows": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if cat, ok := p.Source.(*testCat); ok {
 						return cat.Meows
 					}
@@ -536,12 +537,12 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			},
 		},
 	})
-	petType := types.NewGraphQLUnionType(types.GraphQLUnionTypeConfig{
+	petType := gqltypes.NewGraphQLUnionType(gqltypes.GraphQLUnionTypeConfig{
 		Name: "Pet",
-		Types: []*types.GraphQLObjectType{
+		Types: []*gqltypes.GraphQLObjectType{
 			dogType, catType,
 		},
-		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+		ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 			if _, ok := value.(*testCat); ok {
 				return catType
 			}
@@ -554,13 +555,13 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 			return nil
 		},
 	})
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"pets": &types.GraphQLFieldConfig{
-					Type: types.NewGraphQLList(petType),
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"pets": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.NewGraphQLList(petType),
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						return []interface{}{
 							&testDog{"Odie", true},
 							&testCat{"Garfield", false},
@@ -587,7 +588,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"pets": []interface{}{
 				map[string]interface{}{
@@ -609,7 +610,7 @@ func TestResolveTypeOnUnionYieldsUsefulError(t *testing.T) {
 		},
 	}
 
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 
 	go gql.Graphql(gql.GraphqlParams{
 		Schema:        schema,

--- a/executor/directives_test.go
+++ b/executor/directives_test.go
@@ -1,22 +1,23 @@
 package executor_test
 
 import (
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
-var directivesTestSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-	Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var directivesTestSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+	Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "TestType",
-		Fields: types.GraphQLFieldConfigMap{
-			"a": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"a": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"b": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"b": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
 		},
 	}),
@@ -27,7 +28,7 @@ var directivesTestData map[string]interface{} = map[string]interface{}{
 	"b": func() interface{} { return "b" },
 }
 
-func executeDirectivesTestQuery(t *testing.T, doc string) *types.GraphQLResult {
+func executeDirectivesTestQuery(t *testing.T, doc string) *gqltypes.GraphQLResult {
 	ast := testutil.Parse(t, doc)
 	ep := executor.ExecuteParams{
 		Schema: directivesTestSchema,
@@ -39,7 +40,7 @@ func executeDirectivesTestQuery(t *testing.T, doc string) *types.GraphQLResult {
 
 func TestDirectivesWorksWithoutDirectives(t *testing.T) {
 	query := `{ a, b }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -56,7 +57,7 @@ func TestDirectivesWorksWithoutDirectives(t *testing.T) {
 
 func TestDirectivesWorksOnScalarsIfTrueIncludesScalar(t *testing.T) {
 	query := `{ a, b @include(if: true) }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -73,7 +74,7 @@ func TestDirectivesWorksOnScalarsIfTrueIncludesScalar(t *testing.T) {
 
 func TestDirectivesWorksOnScalarsIfFalseOmitsOnScalar(t *testing.T) {
 	query := `{ a, b @include(if: false) }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -89,7 +90,7 @@ func TestDirectivesWorksOnScalarsIfFalseOmitsOnScalar(t *testing.T) {
 
 func TestDirectivesWorksOnScalarsUnlessFalseIncludesScalar(t *testing.T) {
 	query := `{ a, b @skip(if: false) }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -106,7 +107,7 @@ func TestDirectivesWorksOnScalarsUnlessFalseIncludesScalar(t *testing.T) {
 
 func TestDirectivesWorksOnScalarsUnlessTrueOmitsScalar(t *testing.T) {
 	query := `{ a, b @skip(if: true) }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -130,7 +131,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfFalseOmitsFragmentSpread(t *testing.T
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -154,7 +155,7 @@ func TestDirectivesWorksOnFragmentSpreadsIfTrueIncludesFragmentSpread(t *testing
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -179,7 +180,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessFalseIncludesFragmentSpread(t *te
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -204,7 +205,7 @@ func TestDirectivesWorksOnFragmentSpreadsUnlessTrueOmitsFragmentSpread(t *testin
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -230,7 +231,7 @@ func TestDirectivesWorksOnInlineFragmentIfFalseOmitsInlineFragment(t *testing.T)
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -256,7 +257,7 @@ func TestDirectivesWorksOnInlineFragmentIfTrueIncludesInlineFragment(t *testing.
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -283,7 +284,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessFalseIncludesInlineFragment(t *tes
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -310,7 +311,7 @@ func TestDirectivesWorksOnInlineFragmentUnlessTrueIncludesInlineFragment(t *test
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -334,7 +335,7 @@ func TestDirectivesWorksOnFragmentIfFalseOmitsFragment(t *testing.T) {
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},
@@ -358,7 +359,7 @@ func TestDirectivesWorksOnFragmentIfTrueIncludesFragment(t *testing.T) {
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -383,7 +384,7 @@ func TestDirectivesWorksOnFragmentUnlessFalseIncludesFragment(t *testing.T) {
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -408,7 +409,7 @@ func TestDirectivesWorksOnFragmentUnlessTrueOmitsFragment(t *testing.T) {
           b
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 		},

--- a/executor/executor_schema_test.go
+++ b/executor/executor_schema_test.go
@@ -2,11 +2,12 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
 // TODO: have a separate package for other tests for eg `parser`
@@ -73,40 +74,40 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 		RecentArticle: article("1"),
 	}
 
-	blogImage := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	blogImage := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Image",
-		Fields: types.GraphQLFieldConfigMap{
-			"url": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"url": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"width": &types.GraphQLFieldConfig{
-				Type: types.GraphQLInt,
+			"width": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLInt,
 			},
-			"height": &types.GraphQLFieldConfig{
-				Type: types.GraphQLInt,
+			"height": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLInt,
 			},
 		},
 	})
-	blogAuthor := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	blogAuthor := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Author",
-		Fields: types.GraphQLFieldConfigMap{
-			"id": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"id": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"pic": &types.GraphQLFieldConfig{
+			"pic": &gqltypes.GraphQLFieldConfig{
 				Type: blogImage,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"width": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"width": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
-					"height": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+					"height": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if author, ok := p.Source.(*testAuthor); ok {
 						width := fmt.Sprintf("%v", p.Args["width"])
 						height := fmt.Sprintf("%v", p.Args["height"])
@@ -115,55 +116,55 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 					return nil
 				},
 			},
-			"recentArticle": &types.GraphQLFieldConfig{},
+			"recentArticle": &gqltypes.GraphQLFieldConfig{},
 		},
 	})
-	blogArticle := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	blogArticle := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Article",
-		Fields: types.GraphQLFieldConfigMap{
-			"id": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLNonNull(types.GraphQLString),
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"id": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 			},
-			"isPublished": &types.GraphQLFieldConfig{
-				Type: types.GraphQLBoolean,
+			"isPublished": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLBoolean,
 			},
-			"author": &types.GraphQLFieldConfig{
+			"author": &gqltypes.GraphQLFieldConfig{
 				Type: blogAuthor,
 			},
-			"title": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"title": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"body": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"body": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"keywords": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLList(types.GraphQLString),
+			"keywords": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLList(gqltypes.GraphQLString),
 			},
 		},
 	})
 
-	blogAuthor.AddFieldConfig("recentArticle", &types.GraphQLFieldConfig{
+	blogAuthor.AddFieldConfig("recentArticle", &gqltypes.GraphQLFieldConfig{
 		Type: blogArticle,
 	})
 
-	blogQuery := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	blogQuery := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Query",
-		Fields: types.GraphQLFieldConfigMap{
-			"article": &types.GraphQLFieldConfig{
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"article": &gqltypes.GraphQLFieldConfig{
 				Type: blogArticle,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"id": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLID,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"id": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLID,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					id := p.Args["id"]
 					return article(id)
 				},
 			},
-			"feed": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLList(blogArticle),
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"feed": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLList(blogArticle),
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					return []*testArticle{
 						article(1),
 						article(2),
@@ -181,7 +182,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
 		},
 	})
 
-	blogSchema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	blogSchema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: blogQuery,
 	})
 	if err != nil {
@@ -222,7 +223,7 @@ func TestExecutesUsingAComplexSchema(t *testing.T) {
       }
 	`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"article": map[string]interface{}{
 				"title": "My Article 1",

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3,13 +3,14 @@ package executor_test
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/chris-ramon/graphql-go/errors"
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/language/location"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/errors"
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/language/location"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
 func TestExecutesArbitraryCode(t *testing.T) {
@@ -67,7 +68,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
       }
     `
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"b": "Banana",
 			"x": "Cookie",
@@ -103,7 +104,7 @@ func TestExecutesArbitraryCode(t *testing.T) {
 	}
 
 	// Schema Definitions
-	picResolverFn := func(p types.GQLFRParams) interface{} {
+	picResolverFn := func(p gqltypes.GQLFRParams) interface{} {
 		// get and type assert ResolveFn for this field
 		picResolver, ok := p.Source.(map[string]interface{})["pic"].(func(size int) string)
 		if !ok {
@@ -116,67 +117,67 @@ func TestExecutesArbitraryCode(t *testing.T) {
 		}
 		return picResolver(sizeArg)
 	}
-	dataType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	dataType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "DataType",
-		Fields: types.GraphQLFieldConfigMap{
-			"a": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"a": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"b": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"b": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"c": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"c": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"d": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"d": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"e": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"e": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"f": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"f": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"pic": &types.GraphQLFieldConfig{
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"size": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+			"pic": &gqltypes.GraphQLFieldConfig{
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"size": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Type:    types.GraphQLString,
+				Type:    gqltypes.GraphQLString,
 				Resolve: picResolverFn,
 			},
 		},
 	})
-	deepDataType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	deepDataType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "DeepDataType",
-		Fields: types.GraphQLFieldConfigMap{
-			"a": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"a": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"b": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+			"b": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"c": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLList(types.GraphQLString),
+			"c": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLList(gqltypes.GraphQLString),
 			},
-			"deeper": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLList(dataType),
+			"deeper": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLList(dataType),
 			},
 		},
 	})
 
 	// Exploring a way to have a GraphQLObjectType within itself
 	// in this case DataType has DeepDataType has DataType
-	dataType.AddFieldConfig("deep", &types.GraphQLFieldConfig{
+	dataType.AddFieldConfig("deep", &gqltypes.GraphQLFieldConfig{
 		Type: deepDataType,
 	})
 	// in this case DataType has DataType
-	dataType.AddFieldConfig("promise", &types.GraphQLFieldConfig{
+	dataType.AddFieldConfig("promise", &gqltypes.GraphQLFieldConfig{
 		Type: dataType,
 	})
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: dataType,
 	})
 	if err != nil {
@@ -223,7 +224,7 @@ func TestMergesParallelFragments(t *testing.T) {
       }
     `
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "Apple",
 			"b": "Banana",
@@ -239,38 +240,38 @@ func TestMergesParallelFragments(t *testing.T) {
 		},
 	}
 
-	typeObjectType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	typeObjectType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Type",
-		Fields: types.GraphQLFieldConfigMap{
-			"a": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"a": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					return "Apple"
 				},
 			},
-			"b": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"b": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					return "Banana"
 				},
 			},
-			"c": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+			"c": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					return "Cherry"
 				},
 			},
 		},
 	})
-	deepTypeFieldConfig := &types.GraphQLFieldConfig{
+	deepTypeFieldConfig := &gqltypes.GraphQLFieldConfig{
 		Type: typeObjectType,
-		Resolve: func(p types.GQLFRParams) interface{} {
+		Resolve: func(p gqltypes.GQLFRParams) interface{} {
 			return p.Source
 		},
 	}
 	typeObjectType.AddFieldConfig("deep", deepTypeFieldConfig)
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: typeObjectType,
 	})
 	if err != nil {
@@ -306,13 +307,13 @@ func TestThreadsContextCorrectly(t *testing.T) {
 
 	var resolvedContext map[string]interface{}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						resolvedContext = p.Source.(map[string]interface{})
 						return resolvedContext
 					},
@@ -354,21 +355,21 @@ func TestCorrectlyThreadsArguments(t *testing.T) {
 
 	var resolvedArgs map[string]interface{}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"b": &types.GraphQLFieldConfig{
-					Args: types.GraphQLFieldConfigArgumentMap{
-						"numArg": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLInt,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"b": &gqltypes.GraphQLFieldConfig{
+					Args: gqltypes.GraphQLFieldConfigArgumentMap{
+						"numArg": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLInt,
 						},
-						"stringArg": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLString,
+						"stringArg": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLString,
 						},
 					},
-					Type: types.GraphQLString,
-					Resolve: func(p types.GQLFRParams) interface{} {
+					Type: gqltypes.GraphQLString,
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						resolvedArgs = p.Args
 						return resolvedArgs
 					},
@@ -434,15 +435,15 @@ func TestNullsOutErrorSubtrees(t *testing.T) {
 			panic("Error getting syncError")
 		},
 	}
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"sync": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"sync": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
-				"syncError": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+				"syncError": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -479,18 +480,18 @@ func TestUsesTheInlineOperationIfNoOperationIsProvided(t *testing.T) {
 		"a": "b",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "b",
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -524,18 +525,18 @@ func TestUsesTheOnlyOperationIfNoOperationIsProvided(t *testing.T) {
 		"a": "b",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "b",
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -576,12 +577,12 @@ func TestThrowsIfNoOperationIsProvidedWithMultipleOperations(t *testing.T) {
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -619,26 +620,26 @@ func TestUsesTheQuerySchemaForQueries(t *testing.T) {
 		"c": "d",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "b",
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Q",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
-		Mutation: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+		Mutation: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "M",
-			Fields: types.GraphQLFieldConfigMap{
-				"c": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"c": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -674,26 +675,26 @@ func TestUsesTheMutationSchemaForQueries(t *testing.T) {
 		"c": "d",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"c": "d",
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Q",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
-		Mutation: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+		Mutation: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "M",
-			Fields: types.GraphQLFieldConfigMap{
-				"c": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"c": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -740,7 +741,7 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 		"e": func() interface{} { return "e" },
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "a",
 			"b": "b",
@@ -750,24 +751,24 @@ func TestCorrectFieldOrderingDespiteExecutionOrder(t *testing.T) {
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
-				"b": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+				"b": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
-				"c": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+				"c": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
-				"d": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+				"d": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
-				"e": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+				"e": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -822,18 +823,18 @@ func TestAvoidsRecursion(t *testing.T) {
 		"a": "b",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"a": "b",
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -868,24 +869,24 @@ func TestDoesNotIncludeIllegalFieldsInOutput(t *testing.T) {
       thisIsIllegalDontIncludeMe
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Q",
-			Fields: types.GraphQLFieldConfigMap{
-				"a": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"a": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
-		Mutation: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+		Mutation: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "M",
-			Fields: types.GraphQLFieldConfigMap{
-				"c": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"c": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),
@@ -915,36 +916,36 @@ func TestDoesNotIncludeArgumentsThatWereNotSet(t *testing.T) {
 
 	doc := `{ field(a: true, c: false, e: 0) }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"field": `{"a":true,"c":false,"e":0}`,
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Type",
-			Fields: types.GraphQLFieldConfigMap{
-				"field": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
-					Args: types.GraphQLFieldConfigArgumentMap{
-						"a": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLBoolean,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"field": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
+					Args: gqltypes.GraphQLFieldConfigArgumentMap{
+						"a": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLBoolean,
 						},
-						"b": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLBoolean,
+						"b": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLBoolean,
 						},
-						"c": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLBoolean,
+						"c": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLBoolean,
 						},
-						"d": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLInt,
+						"d": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLInt,
 						},
-						"e": &types.GraphQLArgumentConfig{
-							Type: types.GraphQLInt,
+						"e": &gqltypes.GraphQLArgumentConfig{
+							Type: gqltypes.GraphQLInt,
 						},
 					},
-					Resolve: func(p types.GQLFRParams) interface{} {
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						args, _ := json.Marshal(p.Args)
 						return string(args)
 					},
@@ -991,7 +992,7 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		},
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"specials": []interface{}{
 				map[string]interface{}{
@@ -1008,30 +1009,30 @@ func TestFailsWhenAnIsTypeOfCheckIsNotMet(t *testing.T) {
 		},
 	}
 
-	specialType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	specialType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "SpecialType",
-		IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+		IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 			if _, ok := value.(testSpecialType); ok {
 				return true
 			}
 			return false
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"value": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
-				Resolve: func(p types.GQLFRParams) interface{} {
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"value": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					return p.Source.(testSpecialType).Value
 				},
 			},
 		},
 	})
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"specials": &types.GraphQLFieldConfig{
-					Type: types.NewGraphQLList(specialType),
-					Resolve: func(p types.GQLFRParams) interface{} {
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"specials": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.NewGraphQLList(specialType),
+					Resolve: func(p gqltypes.GQLFRParams) interface{} {
 						return p.Source.(map[string]interface{})["specials"]
 					},
 				},
@@ -1067,7 +1068,7 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 
       type Query { foo: String }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1077,12 +1078,12 @@ func TestFailsToExecuteQueryContainingATypeDefinition(t *testing.T) {
 		},
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "Query",
-			Fields: types.GraphQLFieldConfigMap{
-				"foo": &types.GraphQLFieldConfig{
-					Type: types.GraphQLString,
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"foo": &gqltypes.GraphQLFieldConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 		}),

--- a/executor/lists_test.go
+++ b/executor/lists_test.go
@@ -1,36 +1,37 @@
 package executor_test
 
 import (
-	"github.com/chris-ramon/graphql-go/errors"
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/language/location"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/errors"
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/language/location"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
-func checkList(t *testing.T, testType types.GraphQLType, testData interface{}, expected *types.GraphQLResult) {
+func checkList(t *testing.T, testType gqltypes.GraphQLType, testData interface{}, expected *gqltypes.GraphQLResult) {
 	data := map[string]interface{}{
 		"test": testData,
 	}
 
-	dataType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	dataType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "DataType",
-		Fields: types.GraphQLFieldConfigMap{
-			"test": &types.GraphQLFieldConfig{
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"test": &gqltypes.GraphQLFieldConfig{
 				Type: testType,
 			},
 		},
 	})
-	dataType.AddFieldConfig("nest", &types.GraphQLFieldConfig{
+	dataType.AddFieldConfig("nest", &gqltypes.GraphQLFieldConfig{
 		Type: dataType,
-		Resolve: func(p types.GQLFRParams) interface{} {
+		Resolve: func(p gqltypes.GQLFRParams) interface{} {
 			return data
 		},
 	})
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: dataType,
 	})
 	if err != nil {
@@ -58,11 +59,11 @@ func checkList(t *testing.T, testType types.GraphQLType, testData interface{}, e
 
 // Describe [T] Array<T>
 func TestLists_ListOfNullableObjects_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 	data := []interface{}{
 		1, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -74,11 +75,11 @@ func TestLists_ListOfNullableObjects_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_ListOfNullableObjects_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 	data := []interface{}{
 		1, nil, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -90,8 +91,8 @@ func TestLists_ListOfNullableObjects_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_ListOfNullableObjects_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
-	expected := &types.GraphQLResult{
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -103,7 +104,7 @@ func TestLists_ListOfNullableObjects_ReturnsNull(t *testing.T) {
 
 // Describe [T] Func()Array<T> // equivalent to Promise<Array<T>>
 func TestLists_ListOfNullableFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -112,7 +113,7 @@ func TestLists_ListOfNullableFunc_ContainsValues(t *testing.T) {
 			1, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -124,7 +125,7 @@ func TestLists_ListOfNullableFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_ListOfNullableFunc_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -133,7 +134,7 @@ func TestLists_ListOfNullableFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -145,14 +146,14 @@ func TestLists_ListOfNullableFunc_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_ListOfNullableFunc_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
 	data := func() interface{} {
 		return nil
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -164,7 +165,7 @@ func TestLists_ListOfNullableFunc_ReturnsNull(t *testing.T) {
 
 // Describe [T] Array<Func()<T>> // equivalent to Array<Promise<T>>
 func TestLists_ListOfNullableArrayOfFuncContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -176,7 +177,7 @@ func TestLists_ListOfNullableArrayOfFuncContainsValues(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -188,7 +189,7 @@ func TestLists_ListOfNullableArrayOfFuncContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_ListOfNullableArrayOfFuncContainsNulls(t *testing.T) {
-	ttype := types.NewGraphQLList(types.GraphQLInt)
+	ttype := gqltypes.NewGraphQLList(gqltypes.GraphQLInt)
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -203,7 +204,7 @@ func TestLists_ListOfNullableArrayOfFuncContainsNulls(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -217,11 +218,11 @@ func TestLists_ListOfNullableArrayOfFuncContainsNulls(t *testing.T) {
 
 // Describe [T]! Array<T>
 func TestLists_NonNullListOfNullableObjectsContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 	data := []interface{}{
 		1, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -233,11 +234,11 @@ func TestLists_NonNullListOfNullableObjectsContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 	data := []interface{}{
 		1, nil, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -249,8 +250,8 @@ func TestLists_NonNullListOfNullableObjectsContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
-	expected := &types.GraphQLResult{
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -271,7 +272,7 @@ func TestLists_NonNullListOfNullableObjectsReturnsNull(t *testing.T) {
 
 // Describe [T]! Func()Array<T> // equivalent to Promise<Array<T>>
 func TestLists_NonNullListOfNullableFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -280,7 +281,7 @@ func TestLists_NonNullListOfNullableFunc_ContainsValues(t *testing.T) {
 			1, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -292,7 +293,7 @@ func TestLists_NonNullListOfNullableFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNullableFunc_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -301,7 +302,7 @@ func TestLists_NonNullListOfNullableFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -313,14 +314,14 @@ func TestLists_NonNullListOfNullableFunc_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
 	data := func() interface{} {
 		return nil
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -341,7 +342,7 @@ func TestLists_NonNullListOfNullableFunc_ReturnsNull(t *testing.T) {
 
 // Describe [T]! Array<Func()<T>> // equivalent to Array<Promise<T>>
 func TestLists_NonNullListOfNullableArrayOfFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -353,7 +354,7 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsValues(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -365,7 +366,7 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNullableArrayOfFunc_ContainsNulls(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLInt))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -380,7 +381,7 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsNulls(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -394,11 +395,11 @@ func TestLists_NonNullListOfNullableArrayOfFunc_ContainsNulls(t *testing.T) {
 
 // Describe [T!] Array<T>
 func TestLists_NullableListOfNonNullObjects_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 	data := []interface{}{
 		1, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -410,11 +411,11 @@ func TestLists_NullableListOfNonNullObjects_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 	data := []interface{}{
 		1, nil, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -435,9 +436,9 @@ func TestLists_NullableListOfNonNullObjects_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NullableListOfNonNullObjects_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -449,7 +450,7 @@ func TestLists_NullableListOfNonNullObjects_ReturnsNull(t *testing.T) {
 
 // Describe [T!] Func()Array<T> // equivalent to Promise<Array<T>>
 func TestLists_NullableListOfNonNullFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -458,7 +459,7 @@ func TestLists_NullableListOfNonNullFunc_ContainsValues(t *testing.T) {
 			1, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -470,7 +471,7 @@ func TestLists_NullableListOfNonNullFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -479,7 +480,7 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -500,14 +501,14 @@ func TestLists_NullableListOfNonNullFunc_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NullableListOfNonNullFunc_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
 	data := func() interface{} {
 		return nil
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": nil,
@@ -519,7 +520,7 @@ func TestLists_NullableListOfNonNullFunc_ReturnsNull(t *testing.T) {
 
 // Describe [T!] Array<Func()<T>> // equivalent to Array<Promise<T>>
 func TestLists_NullableListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -531,7 +532,7 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -543,7 +544,7 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
-	ttype := types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt))
+	ttype := gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -558,7 +559,7 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -572,11 +573,11 @@ func TestLists_NullableListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 
 // Describe [T!]! Array<T>
 func TestLists_NonNullListOfNonNullObjects_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 	data := []interface{}{
 		1, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -588,11 +589,11 @@ func TestLists_NonNullListOfNonNullObjects_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 	data := []interface{}{
 		1, nil, 2,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -611,9 +612,9 @@ func TestLists_NonNullListOfNonNullObjects_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -634,7 +635,7 @@ func TestLists_NonNullListOfNonNullObjects_ReturnsNull(t *testing.T) {
 
 // Describe [T!]! Func()Array<T> // equivalent to Promise<Array<T>>
 func TestLists_NonNullListOfNonNullFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -643,7 +644,7 @@ func TestLists_NonNullListOfNonNullFunc_ContainsValues(t *testing.T) {
 			1, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -655,7 +656,7 @@ func TestLists_NonNullListOfNonNullFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -664,7 +665,7 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 			1, nil, 2,
 		}
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -683,14 +684,14 @@ func TestLists_NonNullListOfNonNullFunc_ContainsNull(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
 	// `data` is a function that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
 	data := func() interface{} {
 		return nil
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -711,7 +712,7 @@ func TestLists_NonNullListOfNonNullFunc_ReturnsNull(t *testing.T) {
 
 // Describe [T!]! Array<Func()<T>> // equivalent to Array<Promise<T>>
 func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -723,7 +724,7 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{
@@ -735,7 +736,7 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsValues(t *testing.T) {
 	checkList(t, ttype, data, expected)
 }
 func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
-	ttype := types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLInt)))
+	ttype := gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLInt)))
 
 	// `data` is a slice of functions that return values
 	// Note that its uses the expected signature `func() interface{} {...}`
@@ -750,7 +751,7 @@ func TestLists_NonNullListOfNonNullArrayOfFunc_ContainsNulls(t *testing.T) {
 			return 2
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"test": []interface{}{

--- a/executor/mutations_test.go
+++ b/executor/mutations_test.go
@@ -1,13 +1,14 @@
 package executor_test
 
 import (
-	"github.com/chris-ramon/graphql-go/errors"
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/language/location"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/errors"
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/language/location"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
 // testNumberHolder maps to numberHolderType
@@ -38,77 +39,77 @@ func (r *testRoot) PromiseAndFailToChangeTheNumber(newNumber int) *testNumberHol
 }
 
 // numberHolderType creates a mapping to testNumberHolder
-var numberHolderType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var numberHolderType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "NumberHolder",
-	Fields: types.GraphQLFieldConfigMap{
-		"theNumber": &types.GraphQLFieldConfig{
-			Type: types.GraphQLInt,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"theNumber": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLInt,
 		},
 	},
 })
 
-var mutationsTestSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-	Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var mutationsTestSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+	Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Query",
-		Fields: types.GraphQLFieldConfigMap{
-			"numberHolder": &types.GraphQLFieldConfig{
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"numberHolder": &gqltypes.GraphQLFieldConfig{
 				Type: numberHolderType,
 			},
 		},
 	}),
-	Mutation: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	Mutation: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Mutation",
-		Fields: types.GraphQLFieldConfigMap{
-			"immediatelyChangeTheNumber": &types.GraphQLFieldConfig{
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"immediatelyChangeTheNumber": &gqltypes.GraphQLFieldConfig{
 				Type: numberHolderType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"newNumber": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"newNumber": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
 					return obj.ImmediatelyChangeTheNumber(newNumber)
 				},
 			},
-			"promiseToChangeTheNumber": &types.GraphQLFieldConfig{
+			"promiseToChangeTheNumber": &gqltypes.GraphQLFieldConfig{
 				Type: numberHolderType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"newNumber": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"newNumber": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
 					return obj.PromiseToChangeTheNumber(newNumber)
 				},
 			},
-			"failToChangeTheNumber": &types.GraphQLFieldConfig{
+			"failToChangeTheNumber": &gqltypes.GraphQLFieldConfig{
 				Type: numberHolderType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"newNumber": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"newNumber": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
 					return obj.FailToChangeTheNumber(newNumber)
 				},
 			},
-			"promiseAndFailToChangeTheNumber": &types.GraphQLFieldConfig{
+			"promiseAndFailToChangeTheNumber": &gqltypes.GraphQLFieldConfig{
 				Type: numberHolderType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"newNumber": &types.GraphQLArgumentConfig{
-						Type: types.GraphQLInt,
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"newNumber": &gqltypes.GraphQLArgumentConfig{
+						Type: gqltypes.GraphQLInt,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					newNumber := 0
 					obj, _ := p.Source.(*testRoot)
 					newNumber, _ = p.Args["newNumber"].(int)
@@ -140,7 +141,7 @@ func TestMutations_ExecutionOrdering_EvaluatesMutationsSerially(t *testing.T) {
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"first": map[string]interface{}{
 				"theNumber": 1,
@@ -200,7 +201,7 @@ func TestMutations_EvaluatesMutationsCorrectlyInThePresenceOfAFailedMutation(t *
       }
     }`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"first": map[string]interface{}{
 				"theNumber": 1,

--- a/executor/nonnull_test.go
+++ b/executor/nonnull_test.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 	"github.com/chris-ramon/graphql-go/language/location"
 	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 )
 
 var syncError = "sync"
@@ -47,25 +47,25 @@ var nullingData = map[string]interface{}{
 	},
 }
 
-var dataType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var dataType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "DataType",
-	Fields: types.GraphQLFieldConfigMap{
-		"sync": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"sync": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"nonNullSync": &types.GraphQLFieldConfig{
-			Type: types.NewGraphQLNonNull(types.GraphQLString),
+		"nonNullSync": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 		},
-		"promise": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+		"promise": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"nonNullPromise": &types.GraphQLFieldConfig{
-			Type: types.NewGraphQLNonNull(types.GraphQLString),
+		"nonNullPromise": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 		},
 	},
 })
 
-var nonNullTestSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+var nonNullTestSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 	Query: dataType,
 })
 
@@ -96,17 +96,17 @@ func init() {
 		return nullingData
 	}
 
-	dataType.AddFieldConfig("nest", &types.GraphQLFieldConfig{
+	dataType.AddFieldConfig("nest", &gqltypes.GraphQLFieldConfig{
 		Type: dataType,
 	})
-	dataType.AddFieldConfig("nonNullNest", &types.GraphQLFieldConfig{
-		Type: types.NewGraphQLNonNull(dataType),
+	dataType.AddFieldConfig("nonNullNest", &gqltypes.GraphQLFieldConfig{
+		Type: gqltypes.NewGraphQLNonNull(dataType),
 	})
-	dataType.AddFieldConfig("promiseNest", &types.GraphQLFieldConfig{
+	dataType.AddFieldConfig("promiseNest", &gqltypes.GraphQLFieldConfig{
 		Type: dataType,
 	})
-	dataType.AddFieldConfig("nonNullPromiseNest", &types.GraphQLFieldConfig{
-		Type: types.NewGraphQLNonNull(dataType),
+	dataType.AddFieldConfig("nonNullPromiseNest", &gqltypes.GraphQLFieldConfig{
+		Type: gqltypes.NewGraphQLNonNull(dataType),
 	})
 }
 
@@ -117,7 +117,7 @@ func TestNonNull_NullsANullableFieldThatThrowsSynchronously(t *testing.T) {
         sync
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"sync": nil,
 		},
@@ -155,7 +155,7 @@ func TestNonNull_NullsANullableFieldThatThrowsInAPromise(t *testing.T) {
         promise
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promise": nil,
 		},
@@ -195,7 +195,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANullableFieldThat
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -235,7 +235,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -275,7 +275,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
@@ -315,7 +315,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
@@ -377,7 +377,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatThrow(t *testing.T) {
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"sync":    nil,
@@ -550,7 +550,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldThrowsInALongChainOfField
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest":               nil,
 			"promiseNest":        nil,
@@ -613,7 +613,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNull(t *testing.T) {
         sync
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"sync": nil,
 		},
@@ -644,7 +644,7 @@ func TestNonNull_NullsANullableFieldThatSynchronouslyReturnsNullInAPromise(t *te
         promise
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promise": nil,
 		},
@@ -677,7 +677,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -715,7 +715,7 @@ func TestNonNull_NullsASynchronouslyReturnedObjectThatContainsANonNullableFieldT
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": nil,
 		},
@@ -754,7 +754,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
@@ -792,7 +792,7 @@ func TestNonNull_NullsAnObjectReturnedInAPromiseThatContainsANonNullableFieldTha
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"promiseNest": nil,
 		},
@@ -851,7 +851,7 @@ func TestNonNull_NullsAComplexTreeOfNullableFieldsThatReturnNull(t *testing.T) {
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest": map[string]interface{}{
 				"sync":    nil,
@@ -948,7 +948,7 @@ func TestNonNull_NullsTheFirstNullableObjectAfterAFieldReturnsNullInALongChainOf
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nest":               nil,
 			"promiseNest":        nil,
@@ -1009,7 +1009,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldThrows(t *testing.T) {
 	doc := `
       query Q { nonNullSync }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1041,7 +1041,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldErrors(t *testing.T) {
 	doc := `
       query Q { nonNullPromise }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1073,7 +1073,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldReturnsNull(t *testing.T)
 	doc := `
       query Q { nonNullSync }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1105,7 +1105,7 @@ func TestNonNull_NullsTheTopLevelIfSyncNonNullableFieldResolvesNull(t *testing.T
 	doc := `
       query Q { nonNullPromise }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{

--- a/executor/union_interface_test.go
+++ b/executor/union_interface_test.go
@@ -1,11 +1,12 @@
 package executor_test
 
 import (
-	"github.com/chris-ramon/graphql-go/executor"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
+	"github.com/chris-ramon/graphql-go/testutil"
 )
 
 type testNamedType interface {
@@ -28,56 +29,56 @@ type testPerson struct {
 	Friends []testNamedType `json:"friends"`
 }
 
-var namedType = types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+var namedType = gqltypes.NewGraphQLInterfaceType(gqltypes.GraphQLInterfaceTypeConfig{
 	Name: "Named",
-	Fields: types.GraphQLFieldConfigMap{
-		"name": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"name": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
 	},
 })
-var dogType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var dogType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "Dog",
-	Interfaces: []*types.GraphQLInterfaceType{
+	Interfaces: []*gqltypes.GraphQLInterfaceType{
 		namedType,
 	},
-	Fields: types.GraphQLFieldConfigMap{
-		"name": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"name": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"barks": &types.GraphQLFieldConfig{
-			Type: types.GraphQLBoolean,
+		"barks": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLBoolean,
 		},
 	},
-	IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+	IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 		_, ok := value.(*testDog2)
 		return ok
 	},
 })
-var catType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var catType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "Cat",
-	Interfaces: []*types.GraphQLInterfaceType{
+	Interfaces: []*gqltypes.GraphQLInterfaceType{
 		namedType,
 	},
-	Fields: types.GraphQLFieldConfigMap{
-		"name": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"name": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"meows": &types.GraphQLFieldConfig{
-			Type: types.GraphQLBoolean,
+		"meows": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLBoolean,
 		},
 	},
-	IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+	IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 		_, ok := value.(*testCat2)
 		return ok
 	},
 })
-var petType = types.NewGraphQLUnionType(types.GraphQLUnionTypeConfig{
+var petType = gqltypes.NewGraphQLUnionType(gqltypes.GraphQLUnionTypeConfig{
 	Name: "Pet",
-	Types: []*types.GraphQLObjectType{
+	Types: []*gqltypes.GraphQLObjectType{
 		dogType, catType,
 	},
-	ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+	ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 		if _, ok := value.(*testCat2); ok {
 			return catType
 		}
@@ -87,29 +88,29 @@ var petType = types.NewGraphQLUnionType(types.GraphQLUnionTypeConfig{
 		return nil
 	},
 })
-var personType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var personType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "Person",
-	Interfaces: []*types.GraphQLInterfaceType{
+	Interfaces: []*gqltypes.GraphQLInterfaceType{
 		namedType,
 	},
-	Fields: types.GraphQLFieldConfigMap{
-		"name": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"name": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"pets": &types.GraphQLFieldConfig{
-			Type: types.NewGraphQLList(petType),
+		"pets": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.NewGraphQLList(petType),
 		},
-		"friends": &types.GraphQLFieldConfig{
-			Type: types.NewGraphQLList(namedType),
+		"friends": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.NewGraphQLList(namedType),
 		},
 	},
-	IsTypeOf: func(value interface{}, info types.GraphQLResolveInfo) bool {
+	IsTypeOf: func(value interface{}, info gqltypes.GraphQLResolveInfo) bool {
 		_, ok := value.(*testPerson)
 		return ok
 	},
 })
 
-var unionInterfaceTestSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+var unionInterfaceTestSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 	Query: personType,
 })
 
@@ -151,7 +152,7 @@ func TestUnionIntersectionTypes_CanIntrospectOnUnionAndIntersectionTypes(t *test
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"Named": map[string]interface{}{
 				"kind": "INTERFACE",
@@ -224,7 +225,7 @@ func TestUnionIntersectionTypes_ExecutesUsingUnionTypes(t *testing.T) {
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"__typename": "Person",
 			"name":       "John",
@@ -278,7 +279,7 @@ func TestUnionIntersectionTypes_ExecutesUnionTypesWithInlineFragments(t *testing
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"__typename": "Person",
 			"name":       "John",
@@ -328,7 +329,7 @@ func TestUnionIntersectionTypes_ExecutesUsingInterfaceTypes(t *testing.T) {
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"__typename": "Person",
 			"name":       "John",
@@ -381,7 +382,7 @@ func TestUnionIntersectionTypes_ExecutesInterfaceTypesWithInlineFragments(t *tes
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"__typename": "Person",
 			"name":       "John",
@@ -449,7 +450,7 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
         }
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"__typename": "Person",
 			"name":       "John",
@@ -497,41 +498,41 @@ func TestUnionIntersectionTypes_AllowsFragmentConditionsToBeAbstractTypes(t *tes
 }
 func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 
-	var encounteredSchema *types.GraphQLSchema
+	var encounteredSchema *gqltypes.GraphQLSchema
 	var encounteredRootValue interface{}
 
-	var personType2 *types.GraphQLObjectType
+	var personType2 *gqltypes.GraphQLObjectType
 
-	namedType2 := types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+	namedType2 := gqltypes.NewGraphQLInterfaceType(gqltypes.GraphQLInterfaceTypeConfig{
 		Name: "Named",
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
 		},
-		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+		ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 			encounteredSchema = &info.Schema
 			encounteredRootValue = info.RootValue
 			return personType2
 		},
 	})
 
-	personType2 = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	personType2 = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Person",
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			namedType2,
 		},
-		Fields: types.GraphQLFieldConfigMap{
-			"name": &types.GraphQLFieldConfig{
-				Type: types.GraphQLString,
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.GraphQLString,
 			},
-			"friends": &types.GraphQLFieldConfig{
-				Type: types.NewGraphQLList(namedType2),
+			"friends": &gqltypes.GraphQLFieldConfig{
+				Type: gqltypes.NewGraphQLList(namedType2),
 			},
 		},
 	})
 
-	schema2, _ := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	schema2, _ := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: personType2,
 	})
 
@@ -543,7 +544,7 @@ func TestUnionIntersectionTypes_GetsExecutionInfoInResolver(t *testing.T) {
 	}
 
 	doc := `{ name, friends { name } }`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"name": "John",
 			"friends": []interface{}{

--- a/executor/variables_test.go
+++ b/executor/variables_test.go
@@ -2,17 +2,18 @@ package executor_test
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 	"github.com/chris-ramon/graphql-go/language/ast"
 	"github.com/chris-ramon/graphql-go/language/location"
 	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
-	"reflect"
-	"testing"
 )
 
-var testComplexScalar *types.GraphQLScalarType = types.NewGraphQLScalarType(types.GraphQLScalarTypeConfig{
+var testComplexScalar *gqltypes.GraphQLScalarType = gqltypes.NewGraphQLScalarType(gqltypes.GraphQLScalarTypeConfig{
 	Name: "ComplexScalar",
 	Serialize: func(value interface{}) interface{} {
 		if value == "DeserializedValue" {
@@ -35,25 +36,25 @@ var testComplexScalar *types.GraphQLScalarType = types.NewGraphQLScalarType(type
 	},
 })
 
-var testInputObject *types.GraphQLInputObjectType = types.NewGraphQLInputObjectType(types.InputObjectConfig{
+var testInputObject *gqltypes.GraphQLInputObjectType = gqltypes.NewGraphQLInputObjectType(gqltypes.InputObjectConfig{
 	Name: "TestInputObject",
-	Fields: types.InputObjectConfigFieldMap{
-		"a": &types.InputObjectFieldConfig{
-			Type: types.GraphQLString,
+	Fields: gqltypes.InputObjectConfigFieldMap{
+		"a": &gqltypes.InputObjectFieldConfig{
+			Type: gqltypes.GraphQLString,
 		},
-		"b": &types.InputObjectFieldConfig{
-			Type: types.NewGraphQLList(types.GraphQLString),
+		"b": &gqltypes.InputObjectFieldConfig{
+			Type: gqltypes.NewGraphQLList(gqltypes.GraphQLString),
 		},
-		"c": &types.InputObjectFieldConfig{
-			Type: types.NewGraphQLNonNull(types.GraphQLString),
+		"c": &gqltypes.InputObjectFieldConfig{
+			Type: gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 		},
-		"d": &types.InputObjectFieldConfig{
+		"d": &gqltypes.InputObjectFieldConfig{
 			Type: testComplexScalar,
 		},
 	},
 })
 
-func inputResolved(p types.GQLFRParams) interface{} {
+func inputResolved(p gqltypes.GQLFRParams) interface{} {
 	input, ok := p.Args["input"]
 	if !ok {
 		return nil
@@ -65,78 +66,78 @@ func inputResolved(p types.GQLFRParams) interface{} {
 	return string(b)
 }
 
-var testType *types.GraphQLObjectType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+var testType *gqltypes.GraphQLObjectType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 	Name: "TestType",
-	Fields: types.GraphQLFieldConfigMap{
-		"fieldWithObjectInput": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
+	Fields: gqltypes.GraphQLFieldConfigMap{
+		"fieldWithObjectInput": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
 					Type: testInputObject,
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithNullableStringInput": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.GraphQLString,
+		"fieldWithNullableStringInput": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.GraphQLString,
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithNonNullableStringInput": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.NewGraphQLNonNull(types.GraphQLString),
+		"fieldWithNonNullableStringInput": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"fieldWithDefaultArgumentValue": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type:         types.GraphQLString,
+		"fieldWithDefaultArgumentValue": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type:         gqltypes.GraphQLString,
 					DefaultValue: "Hello World",
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"list": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.NewGraphQLList(types.GraphQLString),
+		"list": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.NewGraphQLList(gqltypes.GraphQLString),
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"nnList": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.NewGraphQLNonNull(types.NewGraphQLList(types.GraphQLString)),
+		"nnList": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.GraphQLString)),
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"listNN": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLString)),
+		"listNN": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString)),
 				},
 			},
 			Resolve: inputResolved,
 		},
-		"nnListNN": &types.GraphQLFieldConfig{
-			Type: types.GraphQLString,
-			Args: types.GraphQLFieldConfigArgumentMap{
-				"input": &types.GraphQLArgumentConfig{
-					Type: types.NewGraphQLNonNull(types.NewGraphQLList(types.NewGraphQLNonNull(types.GraphQLString))),
+		"nnListNN": &gqltypes.GraphQLFieldConfig{
+			Type: gqltypes.GraphQLString,
+			Args: gqltypes.GraphQLFieldConfigArgumentMap{
+				"input": &gqltypes.GraphQLArgumentConfig{
+					Type: gqltypes.NewGraphQLNonNull(gqltypes.NewGraphQLList(gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString))),
 				},
 			},
 			Resolve: inputResolved,
@@ -144,7 +145,7 @@ var testType *types.GraphQLObjectType = types.NewGraphQLObjectType(types.GraphQL
 	},
 })
 
-var variablesTestSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+var variablesTestSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 	Query: testType,
 })
 
@@ -154,7 +155,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ExecutesWithComplexI
           fieldWithObjectInput(input: {a: "foo", b: ["bar"], c: "baz"})
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
@@ -181,7 +182,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_ProperlyParsesSingle
           fieldWithObjectInput(input: {a: "foo", b: "bar", c: "baz"})
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
@@ -208,7 +209,7 @@ func TestVariables_ObjectsAndNullability_UsingInlineStructs_DoesNotUseIncorrectV
           fieldWithObjectInput(input: ["foo", "bar", "baz"])
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": nil,
 		},
@@ -247,7 +248,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexInput
 			"c": "baz",
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
@@ -277,7 +278,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_UsesDefaultValueWhenNotP
 		fieldWithObjectInput(input: $input)
 	  }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
@@ -306,7 +307,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ProperlyParsesSingleValu
 			"c": "baz",
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"a":"foo","b":["bar"],"c":"baz"}`,
 		},
@@ -335,7 +336,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ExecutesWithComplexScala
 			"d": "SerializedValue",
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithObjectInput": `{"c":"foo","d":"DeserializedValue"}`,
 		},
@@ -365,7 +366,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnNullForNestedNon
 			"c": nil,
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -400,7 +401,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnIncorrectType(t 
 	params := map[string]interface{}{
 		"input": "foo bar",
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -438,7 +439,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnOmissionOfNested
 			"b": "bar",
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -478,7 +479,7 @@ func TestVariables_ObjectsAndNullability_UsingVariables_ErrorsOnAdditionOfUnknow
 			"d": "dog",
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -516,7 +517,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmitted(t *testing.T)
         fieldWithNullableStringInput
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": nil,
 		},
@@ -543,7 +544,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAVariable(t 
         fieldWithNullableStringInput(input: $value)
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": nil,
 		},
@@ -570,7 +571,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeOmittedInAnUnlistedVa
         fieldWithNullableStringInput(input: $value)
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": nil,
 		},
@@ -600,7 +601,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToNullInAVariable(
 	params := map[string]interface{}{
 		"value": nil,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": nil,
 		},
@@ -631,7 +632,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueInAVariabl
 	params := map[string]interface{}{
 		"value": "a",
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": `"a"`,
 		},
@@ -659,7 +660,7 @@ func TestVariables_NullableScalars_AllowsNullableInputsToBeSetToAValueDirectly(t
         fieldWithNullableStringInput(input: "a")
       }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNullableStringInput": `"a"`,
 		},
@@ -689,7 +690,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeOmittedIn
         }
 	`
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -728,7 +729,7 @@ func TestVariables_NonNullableScalars_DoesNotAllowNonNullableInputsToBeSetToNull
 	params := map[string]interface{}{
 		"value": nil,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -768,7 +769,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueInAV
 	params := map[string]interface{}{
 		"value": "a",
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNonNullableStringInput": `"a"`,
 		},
@@ -801,7 +802,7 @@ func TestVariables_NonNullableScalars_AllowsNonNullableInputsToBeSetToAValueDire
 		"value": "a",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNonNullableStringInput": `"a"`,
 		},
@@ -834,7 +835,7 @@ func TestVariables_NonNullableScalars_PassesAlongNullForNonNullableInputsIfExpli
 		"value": "a",
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithNonNullableStringInput": nil,
 		},
@@ -867,7 +868,7 @@ func TestVariables_ListsAndNullability_AllowsListsToBeNull(t *testing.T) {
 		"input": nil,
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"list": nil,
 		},
@@ -898,7 +899,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainValues(t *testing.T) 
 		"input": []interface{}{"A"},
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"list": `["A"]`,
 		},
@@ -929,7 +930,7 @@ func TestVariables_ListsAndNullability_AllowsListsToContainNull(t *testing.T) {
 		"input": []interface{}{"A", nil, "B"},
 	}
 
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"list": `["A",null,"B"]`,
 		},
@@ -956,7 +957,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListsToBeNull(t *testi
           nnList(input: $input)
         }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -993,7 +994,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainValues(t *test
 	params := map[string]interface{}{
 		"input": []interface{}{"A"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nnList": `["A"]`,
 		},
@@ -1023,7 +1024,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsToContainNull(t *testin
 	params := map[string]interface{}{
 		"input": []interface{}{"A", nil, "B"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nnList": `["A",null,"B"]`,
 		},
@@ -1053,7 +1054,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToBeNull(t *testing.
 	params := map[string]interface{}{
 		"input": nil,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"listNN": nil,
 		},
@@ -1083,7 +1084,7 @@ func TestVariables_ListsAndNullability_AllowsListsOfNonNullsToContainValues(t *t
 	params := map[string]interface{}{
 		"input": []interface{}{"A"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"listNN": `["A"]`,
 		},
@@ -1113,7 +1114,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowListOfNonNullsToContainNull(t
 	params := map[string]interface{}{
 		"input": []interface{}{"A", nil, "B"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1152,7 +1153,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToBeNull
 	params := map[string]interface{}{
 		"input": nil,
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1190,7 +1191,7 @@ func TestVariables_ListsAndNullability_AllowsNonNullListsOfNonNulsToContainValue
 	params := map[string]interface{}{
 		"input": []interface{}{"A"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"nnListNN": `["A"]`,
 		},
@@ -1220,7 +1221,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowNonNullListOfNonNullsToContai
 	params := map[string]interface{}{
 		"input": []interface{}{"A", nil, "B"},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1261,7 +1262,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowInvalidTypesToBeUsedAsValues(
 			"list": []interface{}{"A", "B"},
 		},
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1299,7 +1300,7 @@ func TestVariables_ListsAndNullability_DoesNotAllowUnknownTypesToBeUsedAsValues(
 	params := map[string]interface{}{
 		"input": "whoknows",
 	}
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: nil,
 		Errors: []graphqlerrors.GraphQLFormattedError{
 			graphqlerrors.GraphQLFormattedError{
@@ -1335,7 +1336,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNoArgumentProvided(t *testing.T
       fieldWithDefaultArgumentValue
     }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},
@@ -1361,7 +1362,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenNullableVariableProvided(t *tes
         fieldWithDefaultArgumentValue(input: $optional)
     }
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},
@@ -1387,7 +1388,7 @@ func TestVariables_UsesArgumentDefaultValues_WhenArgumentProvidedCannotBeParsed(
 		fieldWithDefaultArgumentValue(input: WRONG_TYPE)
 	}
 	`
-	expected := &types.GraphQLResult{
+	expected := &gqltypes.GraphQLResult{
 		Data: map[string]interface{}{
 			"fieldWithDefaultArgumentValue": `"Hello World"`,
 		},

--- a/gqltypes/definition.go
+++ b/gqltypes/definition.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"fmt"

--- a/gqltypes/directives.go
+++ b/gqltypes/directives.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 type GraphQLDirective struct {
 	Name        string

--- a/gqltypes/introspection.go
+++ b/gqltypes/introspection.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"fmt"

--- a/gqltypes/introspection_test.go
+++ b/gqltypes/introspection_test.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"testing"

--- a/gqltypes/scalars.go
+++ b/gqltypes/scalars.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"fmt"

--- a/gqltypes/scalars_serialization_test.go
+++ b/gqltypes/scalars_serialization_test.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"math"

--- a/gqltypes/schema.go
+++ b/gqltypes/schema.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"fmt"

--- a/gqltypes/types.go
+++ b/gqltypes/types.go
@@ -1,4 +1,4 @@
-package types
+package gqltypes
 
 import (
 	"fmt"

--- a/graphql.go
+++ b/graphql.go
@@ -3,28 +3,28 @@ package gql
 import (
 	"github.com/chris-ramon/graphql-go/errors"
 	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 	"github.com/chris-ramon/graphql-go/language/parser"
 	"github.com/chris-ramon/graphql-go/language/source"
-	"github.com/chris-ramon/graphql-go/types"
 	"github.com/chris-ramon/graphql-go/validator"
 )
 
 type GraphqlParams struct {
-	Schema         types.GraphQLSchema
+	Schema         gqltypes.GraphQLSchema
 	RequestString  string
 	RootObject     map[string]interface{}
 	VariableValues map[string]interface{}
 	OperationName  string
 }
 
-func Graphql(p GraphqlParams, resultChannel chan *types.GraphQLResult) {
+func Graphql(p GraphqlParams, resultChannel chan *gqltypes.GraphQLResult) {
 	source := source.NewSource(&source.Source{
 		Body: p.RequestString,
 		Name: "GraphQL request",
 	})
 	AST, err := parser.Parse(parser.ParseParams{Source: source})
 	if err != nil {
-		result := types.GraphQLResult{
+		result := gqltypes.GraphQLResult{
 			Errors: graphqlerrors.FormatErrors(err),
 		}
 		resultChannel <- &result
@@ -33,7 +33,7 @@ func Graphql(p GraphqlParams, resultChannel chan *types.GraphQLResult) {
 	validationResult := validator.ValidateDocument(p.Schema, AST)
 
 	if !validationResult.IsValid {
-		result := types.GraphQLResult{
+		result := gqltypes.GraphQLResult{
 			Errors: validationResult.Errors,
 		}
 		resultChannel <- &result

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1,17 +1,18 @@
 package gql
 
 import (
+	"log"
 	"reflect"
 	"testing"
 
-	"github.com/chris-ramon/graphql-go/types"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 
 	"./testutil"
 )
 
 type T struct {
 	Query    string
-	Schema   types.GraphQLSchema
+	Schema   gqltypes.GraphQLSchema
 	Expected interface{}
 }
 
@@ -26,7 +27,7 @@ var (
 				}
 			`,
 			Schema: testutil.StarWarsSchema,
-			Expected: &types.GraphQLResult{
+			Expected: &gqltypes.GraphQLResult{
 				Data: map[string]interface{}{
 					"hero": map[string]interface{}{
 						"name": "R2-D2",
@@ -47,7 +48,7 @@ var (
 				}
 				`,
 			Schema: testutil.StarWarsSchema,
-			Expected: &types.GraphQLResult{
+			Expected: &gqltypes.GraphQLResult{
 				Data: map[string]interface{}{
 					"hero": map[string]interface{}{
 						"id":   "2001",
@@ -81,7 +82,7 @@ func TestQuery(t *testing.T) {
 }
 
 func testGraphql(test T, p GraphqlParams, t *testing.T) {
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 	go Graphql(p, resultChannel)
 	result := <-resultChannel
 	if len(result.Errors) > 0 {
@@ -95,17 +96,17 @@ func testGraphql(test T, p GraphqlParams, t *testing.T) {
 func TestBasicGraphQLExample(t *testing.T) {
 	// taken from `graphql-js` README
 
-	helloFieldResolved := func(p types.GQLFRParams) interface{} {
+	helloFieldResolved := func(p gqltypes.GQLFRParams) interface{} {
 		return "world"
 	}
 
-	schema, err := types.NewGraphQLSchema(types.GraphQLSchemaConfig{
-		Query: types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	schema, err := gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
+		Query: gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 			Name: "RootQueryType",
-			Fields: types.GraphQLFieldConfigMap{
-				"hello": &types.GraphQLFieldConfig{
+			Fields: gqltypes.GraphQLFieldConfigMap{
+				"hello": &gqltypes.GraphQLFieldConfig{
 					Description: "Returns `world`",
-					Type:        types.GraphQLString,
+					Type:        gqltypes.GraphQLString,
 					Resolve:     helloFieldResolved,
 				},
 			},
@@ -120,12 +121,13 @@ func TestBasicGraphQLExample(t *testing.T) {
 		"hello": "world",
 	}
 
-	resultChannel := make(chan *types.GraphQLResult)
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 	go Graphql(GraphqlParams{
 		Schema:        schema,
 		RequestString: query,
 	}, resultChannel)
 	result := <-resultChannel
+	log.Printf("result: %v", result)
 	if len(result.Errors) > 0 {
 		t.Fatalf("wrong result, unexpected errors: %v", result.Errors)
 	}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 
 	"github.com/chris-ramon/graphql-go/executor"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 	"github.com/chris-ramon/graphql-go/language/ast"
 	"github.com/chris-ramon/graphql-go/language/parser"
-	"github.com/chris-ramon/graphql-go/types"
 	"github.com/kr/pretty"
 )
 
@@ -22,10 +22,10 @@ var (
 	Artoo          StarWarsChar
 	HumanData      map[int]StarWarsChar
 	DroidData      map[int]StarWarsChar
-	StarWarsSchema types.GraphQLSchema
+	StarWarsSchema gqltypes.GraphQLSchema
 
-	humanType *types.GraphQLObjectType
-	droidType *types.GraphQLObjectType
+	humanType *gqltypes.GraphQLObjectType
+	droidType *gqltypes.GraphQLObjectType
 )
 
 type StarWarsChar struct {
@@ -97,43 +97,43 @@ func init() {
 		2001: Artoo,
 	}
 
-	episodeEnum := types.NewGraphQLEnumType(types.GraphQLEnumTypeConfig{
+	episodeEnum := gqltypes.NewGraphQLEnumType(gqltypes.GraphQLEnumTypeConfig{
 		Name:        "Episode",
 		Description: "One of the films in the Star Wars Trilogy",
-		Values: types.GraphQLEnumValueConfigMap{
-			"NEWHOPE": types.GraphQLEnumValueConfig{
+		Values: gqltypes.GraphQLEnumValueConfigMap{
+			"NEWHOPE": gqltypes.GraphQLEnumValueConfig{
 				Value:       4,
 				Description: "Released in 1977.",
 			},
-			"EMPIRE": types.GraphQLEnumValueConfig{
+			"EMPIRE": gqltypes.GraphQLEnumValueConfig{
 				Value:       5,
 				Description: "Released in 1980.",
 			},
-			"JEDI": types.GraphQLEnumValueConfig{
+			"JEDI": gqltypes.GraphQLEnumValueConfig{
 				Value:       6,
 				Description: "Released in 1983.",
 			},
 		},
 	})
 
-	characterInterface := types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+	characterInterface := gqltypes.NewGraphQLInterfaceType(gqltypes.GraphQLInterfaceTypeConfig{
 		Name:        "Character",
 		Description: "A character in the Star Wars Trilogy",
-		Fields: types.GraphQLFieldConfigMap{
-			"id": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLNonNull(types.GraphQLString),
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"id": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 				Description: "The id of the character.",
 			},
-			"name": &types.GraphQLFieldConfig{
-				Type:        types.GraphQLString,
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.GraphQLString,
 				Description: "The name of the character.",
 			},
-			"appearsIn": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLList(episodeEnum),
+			"appearsIn": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLList(episodeEnum),
 				Description: "Which movies they appear in.",
 			},
 		},
-		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+		ResolveType: func(value interface{}, info gqltypes.GraphQLResolveInfo) *gqltypes.GraphQLObjectType {
 			if character, ok := value.(StarWarsChar); ok {
 				id, _ := strconv.Atoi(character.Id)
 				human := GetHuman(id)
@@ -144,59 +144,59 @@ func init() {
 			return droidType
 		},
 	})
-	characterInterface.AddFieldConfig("friends", &types.GraphQLFieldConfig{
-		Type:        types.NewGraphQLList(characterInterface),
+	characterInterface.AddFieldConfig("friends", &gqltypes.GraphQLFieldConfig{
+		Type:        gqltypes.NewGraphQLList(characterInterface),
 		Description: "The friends of the character, or an empty list if they have none.",
 	})
 
-	humanType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	humanType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name:        "Human",
 		Description: "A humanoid creature in the Star Wars universe.",
-		Fields: types.GraphQLFieldConfigMap{
-			"id": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLNonNull(types.GraphQLString),
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"id": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 				Description: "The id of the human.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Id
 					}
 					return nil
 				},
 			},
-			"name": &types.GraphQLFieldConfig{
-				Type:        types.GraphQLString,
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.GraphQLString,
 				Description: "The name of the human.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Name
 					}
 					return nil
 				},
 			},
-			"friends": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLList(characterInterface),
+			"friends": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLList(characterInterface),
 				Description: "The friends of the human, or an empty list if they have none.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.Friends
 					}
 					return []interface{}{}
 				},
 			},
-			"appearsIn": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLList(episodeEnum),
+			"appearsIn": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.AppearsIn
 					}
 					return nil
 				},
 			},
-			"homePlanet": &types.GraphQLFieldConfig{
-				Type:        types.GraphQLString,
+			"homePlanet": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.GraphQLString,
 				Description: "The home planet of the human, or null if unknown.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if human, ok := p.Source.(StarWarsChar); ok {
 						return human.HomePlanet
 					}
@@ -204,38 +204,38 @@ func init() {
 				},
 			},
 		},
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			characterInterface,
 		},
 	})
-	droidType = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	droidType = gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name:        "Droid",
 		Description: "A mechanical creature in the Star Wars universe.",
-		Fields: types.GraphQLFieldConfigMap{
-			"id": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLNonNull(types.GraphQLString),
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"id": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 				Description: "The id of the droid.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Id
 					}
 					return nil
 				},
 			},
-			"name": &types.GraphQLFieldConfig{
-				Type:        types.GraphQLString,
+			"name": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.GraphQLString,
 				Description: "The name of the droid.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.Name
 					}
 					return nil
 				},
 			},
-			"friends": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLList(characterInterface),
+			"friends": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLList(characterInterface),
 				Description: "The friends of the droid, or an empty list if they have none.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						friends := []map[string]interface{}{}
 						for _, friend := range droid.Friends {
@@ -249,20 +249,20 @@ func init() {
 					return []interface{}{}
 				},
 			},
-			"appearsIn": &types.GraphQLFieldConfig{
-				Type:        types.NewGraphQLList(episodeEnum),
+			"appearsIn": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.NewGraphQLList(episodeEnum),
 				Description: "Which movies they appear in.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.AppearsIn
 					}
 					return nil
 				},
 			},
-			"primaryFunction": &types.GraphQLFieldConfig{
-				Type:        types.GraphQLString,
+			"primaryFunction": &gqltypes.GraphQLFieldConfig{
+				Type:        gqltypes.GraphQLString,
 				Description: "The primary function of the droid.",
-				Resolve: func(p types.GQLFRParams) interface{} {
+				Resolve: func(p gqltypes.GQLFRParams) interface{} {
 					if droid, ok := p.Source.(StarWarsChar); ok {
 						return droid.PrimaryFunction
 					}
@@ -270,54 +270,54 @@ func init() {
 				},
 			},
 		},
-		Interfaces: []*types.GraphQLInterfaceType{
+		Interfaces: []*gqltypes.GraphQLInterfaceType{
 			characterInterface,
 		},
 	})
 
-	queryType := types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+	queryType := gqltypes.NewGraphQLObjectType(gqltypes.GraphQLObjectTypeConfig{
 		Name: "Query",
-		Fields: types.GraphQLFieldConfigMap{
-			"hero": &types.GraphQLFieldConfig{
+		Fields: gqltypes.GraphQLFieldConfigMap{
+			"hero": &gqltypes.GraphQLFieldConfig{
 				Type: characterInterface,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"episode": &types.GraphQLArgumentConfig{
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"episode": &gqltypes.GraphQLArgumentConfig{
 						Description: "If omitted, returns the hero of the whole saga. If " +
 							"provided, returns the hero of that particular episode.",
 						Type: episodeEnum,
 					},
 				},
-				Resolve: func(p types.GQLFRParams) (r interface{}) {
+				Resolve: func(p gqltypes.GQLFRParams) (r interface{}) {
 					return GetHero(p.Args["episode"])
 				},
 			},
-			"human": &types.GraphQLFieldConfig{
+			"human": &gqltypes.GraphQLFieldConfig{
 				Type: humanType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"id": &types.GraphQLArgumentConfig{
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"id": &gqltypes.GraphQLArgumentConfig{
 						Description: "id of the human",
-						Type:        types.NewGraphQLNonNull(types.GraphQLString),
+						Type:        gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 					},
 				},
-				Resolve: func(p types.GQLFRParams) (r interface{}) {
+				Resolve: func(p gqltypes.GQLFRParams) (r interface{}) {
 					return GetHuman(p.Args["id"].(int))
 				},
 			},
-			"droid": &types.GraphQLFieldConfig{
+			"droid": &gqltypes.GraphQLFieldConfig{
 				Type: droidType,
-				Args: types.GraphQLFieldConfigArgumentMap{
-					"id": &types.GraphQLArgumentConfig{
+				Args: gqltypes.GraphQLFieldConfigArgumentMap{
+					"id": &gqltypes.GraphQLArgumentConfig{
 						Description: "id of the droid",
-						Type:        types.NewGraphQLNonNull(types.GraphQLString),
+						Type:        gqltypes.NewGraphQLNonNull(gqltypes.GraphQLString),
 					},
 				},
-				Resolve: func(p types.GQLFRParams) (r interface{}) {
+				Resolve: func(p gqltypes.GQLFRParams) (r interface{}) {
 					return GetDroid(p.Args["id"].(int))
 				},
 			},
 		},
 	})
-	StarWarsSchema, _ = types.NewGraphQLSchema(types.GraphQLSchemaConfig{
+	StarWarsSchema, _ = gqltypes.NewGraphQLSchema(gqltypes.GraphQLSchemaConfig{
 		Query: queryType,
 	})
 }
@@ -356,8 +356,8 @@ func Parse(t *testing.T, query string) *ast.Document {
 	}
 	return astDoc
 }
-func Execute(t *testing.T, ep executor.ExecuteParams) *types.GraphQLResult {
-	resultChannel := make(chan *types.GraphQLResult)
+func Execute(t *testing.T, ep executor.ExecuteParams) *gqltypes.GraphQLResult {
+	resultChannel := make(chan *gqltypes.GraphQLResult)
 	go executor.Execute(ep, resultChannel)
 	result := <-resultChannel
 	return result

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -2,8 +2,8 @@ package validator
 
 import (
 	"github.com/chris-ramon/graphql-go/errors"
+	"github.com/chris-ramon/graphql-go/gqltypes"
 	"github.com/chris-ramon/graphql-go/language/ast"
-	"github.com/chris-ramon/graphql-go/types"
 )
 
 type ValidationResult struct {
@@ -11,7 +11,7 @@ type ValidationResult struct {
 	Errors  []graphqlerrors.GraphQLFormattedError
 }
 
-func ValidateDocument(schema types.GraphQLSchema, ast *ast.Document) (vr ValidationResult) {
+func ValidateDocument(schema gqltypes.GraphQLSchema, ast *ast.Document) (vr ValidationResult) {
 	vr.IsValid = true
 	return vr
 }


### PR DESCRIPTION
#### Details

Renames `types` pkg name to `gqltypes` so `graphql-go` users can have the `types` pkg name available to use for their programs.

I went ahead a named `gqltypes` instead of `GQLTypes` or `gqlTypes` or something else, because of go's package naming convention, as explained here: [package-names](https://blog.golang.org/package-names).