### PR TITLE
Improvements on `types` package.

### DIFF
--- a/types/definition.go
+++ b/types/definition.go
@@ -1058,10 +1058,11 @@ func (st *InputObjectField) GetError() error {
 
 type InputObjectConfigFieldMap map[string]*InputObjectFieldConfig
 type InputObjectFieldMap map[string]*InputObjectField
+type InputObjectConfigFieldMapThunk func() InputObjectConfigFieldMap
 type InputObjectConfig struct {
-	Name        string                    `json:"name"`
-	Fields      InputObjectConfigFieldMap `json:"fields"`
-	Description string                    `json:"description"`
+	Name        string      `json:"name"`
+	Fields      interface{} `json:"fields"`
+	Description string      `json:"description"`
 }
 
 // TODO: rename InputObjectConfig to GraphQLInputObjecTypeConfig for consistency?
@@ -1081,7 +1082,13 @@ func NewGraphQLInputObjectType(config InputObjectConfig) *GraphQLInputObjectType
 }
 
 func (gt *GraphQLInputObjectType) defineFieldMap() InputObjectFieldMap {
-	fieldMap := gt.typeConfig.Fields
+	var fieldMap InputObjectConfigFieldMap
+	switch gt.typeConfig.Fields.(type) {
+	case InputObjectConfigFieldMap:
+		fieldMap = gt.typeConfig.Fields.(InputObjectConfigFieldMap)
+	case InputObjectConfigFieldMapThunk:
+		fieldMap = gt.typeConfig.Fields.(InputObjectConfigFieldMapThunk)()
+	}
 	resultFieldMap := InputObjectFieldMap{}
 
 	err := invariant(

--- a/types/definition.go
+++ b/types/definition.go
@@ -425,7 +425,7 @@ func defineFieldMap(ttype GraphQLNamedType, fields GraphQLFieldConfigMap) (Graph
 
 	err := invariant(
 		len(fields) > 0,
-		fmt.Sprintf(`%v fields must be an object with field names as keys.`, ttype),
+		fmt.Sprintf(`%v fields must be an object with field names as keys or a function which return such an object.`, ttype),
 	)
 	if err != nil {
 		return resultFieldMap, err
@@ -1086,7 +1086,7 @@ func (gt *GraphQLInputObjectType) defineFieldMap() InputObjectFieldMap {
 
 	err := invariant(
 		len(fieldMap) > 0,
-		fmt.Sprintf(`%v fields must be an object with field names as keys.`, gt),
+		fmt.Sprintf(`%v fields must be an object with field names as keys or a function which return such an object.`, gt),
 	)
 	if err != nil {
 		gt.err = err

--- a/types/definition.go
+++ b/types/definition.go
@@ -54,6 +54,26 @@ func IsInputType(ttype GraphQLType) bool {
 	return false
 }
 
+func IsOutputType(ttype GraphQLType) bool {
+	namedType := GetNamedType(ttype)
+	if _, ok := namedType.(*GraphQLScalarType); ok {
+		return true
+	}
+	if _, ok := namedType.(*GraphQLObjectType); ok {
+		return true
+	}
+	if _, ok := namedType.(*GraphQLInterfaceType); ok {
+		return true
+	}
+	if _, ok := namedType.(*GraphQLUnionType); ok {
+		return true
+	}
+	if _, ok := namedType.(*GraphQLEnumType); ok {
+		return true
+	}
+	return false
+}
+
 // These types may be used as output types as the result of fields.
 type GraphQLOutputType interface {
 	GetName() string

--- a/types/definition_test.go
+++ b/types/definition_test.go
@@ -146,6 +146,9 @@ func TestTypeSystem_DefinitionExample_DefinesAQueryOnlySchema(t *testing.T) {
 	if articleFieldType.GetName() != "Article" {
 		t.Fatalf("articleFieldType.Name expected to equal `Article`, got: %v", articleField.Type.GetName())
 	}
+	if articleField.Name != "article" {
+		t.Fatalf("articleField.Name expected to equal `article`, got: %v", articleField.Name)
+	}
 	articleFieldTypeObject, ok := articleFieldType.(*types.GraphQLObjectType)
 	if !ok {
 		t.Fatalf("expected articleFieldType to be *types.GraphQLObjectType`, got: %v", articleField)

--- a/types/definition_test.go
+++ b/types/definition_test.go
@@ -2,10 +2,11 @@ package types_test
 
 import (
 	"fmt"
-	"github.com/chris-ramon/graphql-go/testutil"
-	"github.com/chris-ramon/graphql-go/types"
 	"reflect"
 	"testing"
+
+	"github.com/chris-ramon/graphql-go/testutil"
+	"github.com/chris-ramon/graphql-go/types"
 )
 
 var blogImage = types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
@@ -328,6 +329,60 @@ func TestTypeSystem_DefinitionExample_StringifiesSimpleTypes(t *testing.T) {
 	for _, test := range tests {
 		ttypeStr := fmt.Sprintf("%v", test.ttype)
 		if ttypeStr != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+	}
+}
+
+func TestTypeSystem_IdentifiesInputTypes(t *testing.T) {
+	type Test struct {
+		ttype    types.GraphQLType
+		expected bool
+	}
+	tests := []Test{
+		Test{types.GraphQLInt, true},
+		Test{objectType, false},
+		Test{interfaceType, false},
+		Test{unionType, false},
+		Test{enumType, true},
+		Test{inputObjectType, true},
+	}
+	for _, test := range tests {
+		ttypeStr := fmt.Sprintf("%v", test.ttype)
+		if types.IsInputType(test.ttype) != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+		if types.IsInputType(types.NewGraphQLList(test.ttype)) != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+		if types.IsInputType(types.NewGraphQLNonNull(test.ttype)) != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+	}
+}
+
+func TestTypeSystem_IdentifiesOutputTypes(t *testing.T) {
+	type Test struct {
+		ttype    types.GraphQLType
+		expected bool
+	}
+	tests := []Test{
+		Test{types.GraphQLInt, true},
+		Test{objectType, true},
+		Test{interfaceType, true},
+		Test{unionType, true},
+		Test{enumType, true},
+		Test{inputObjectType, false},
+	}
+	for _, test := range tests {
+		ttypeStr := fmt.Sprintf("%v", test.ttype)
+		if types.IsOutputType(test.ttype) != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+		if types.IsOutputType(types.NewGraphQLList(test.ttype)) != test.expected {
+			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
+		}
+		if types.IsOutputType(types.NewGraphQLNonNull(test.ttype)) != test.expected {
 			t.Fatalf(`expected %v , got: %v`, test.expected, ttypeStr)
 		}
 	}

--- a/types/definition_test.go
+++ b/types/definition_test.go
@@ -334,7 +334,7 @@ func TestTypeSystem_DefinitionExample_StringifiesSimpleTypes(t *testing.T) {
 	}
 }
 
-func TestTypeSystem_IdentifiesInputTypes(t *testing.T) {
+func TestTypeSystem_DefinitionExample_IdentifiesInputTypes(t *testing.T) {
 	type Test struct {
 		ttype    types.GraphQLType
 		expected bool
@@ -361,7 +361,7 @@ func TestTypeSystem_IdentifiesInputTypes(t *testing.T) {
 	}
 }
 
-func TestTypeSystem_IdentifiesOutputTypes(t *testing.T) {
+func TestTypeSystem_DefinitionExample_IdentifiesOutputTypes(t *testing.T) {
 	type Test struct {
 		ttype    types.GraphQLType
 		expected bool

--- a/types/scalars.go
+++ b/types/scalars.go
@@ -28,7 +28,7 @@ func coerceInt(value interface{}) interface{} {
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
-			return int(0)
+			return nil
 		}
 		return coerceInt(val)
 	}

--- a/types/scalars.go
+++ b/types/scalars.go
@@ -2,8 +2,14 @@ package types
 
 import (
 	"fmt"
-	"github.com/chris-ramon/graphql-go/language/ast"
 	"strconv"
+
+	"github.com/chris-ramon/graphql-go/language/ast"
+)
+
+var (
+	MaxInt = 9007199254740991
+	MinInt = -9007199254740991
 )
 
 func coerceInt(value interface{}) interface{} {
@@ -16,9 +22,9 @@ func coerceInt(value interface{}) interface{} {
 	case int:
 		return value
 	case float32:
-		return int(value)
+		return intOrNil(int(value))
 	case float64:
-		return int(value)
+		return intOrNil(int(value))
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
@@ -27,6 +33,16 @@ func coerceInt(value interface{}) interface{} {
 		return coerceInt(val)
 	}
 	return int(0)
+}
+
+// Integers are only safe when between -(2^53 - 1) and 2^53 - 1 due to being
+// encoded in JavaScript and represented in JSON as double-precision floating
+// point numbers, as specified by IEEE 754.
+func intOrNil(value int) interface{} {
+	if value <= MaxInt && value >= MinInt {
+		return value
+	}
+	return nil
 }
 
 var GraphQLInt *GraphQLScalarType = NewGraphQLScalarType(GraphQLScalarTypeConfig{

--- a/types/scalars.go
+++ b/types/scalars.go
@@ -124,10 +124,11 @@ func coerceBool(value interface{}) interface{} {
 	case bool:
 		return value
 	case string:
-		if value == "true" {
-			return true
+		switch value {
+		case "", "false":
+			return false
 		}
-		return false
+		return true
 	case float64:
 		if value != 0 {
 			return true

--- a/types/scalars.go
+++ b/types/scalars.go
@@ -76,7 +76,7 @@ func coerceFloat32(value interface{}) interface{} {
 	case string:
 		val, err := strconv.ParseFloat(value, 0)
 		if err != nil {
-			return float32(0)
+			return nil
 		}
 		return coerceFloat32(val)
 	}

--- a/types/scalars_serialization_test.go
+++ b/types/scalars_serialization_test.go
@@ -1,14 +1,13 @@
 package types
 
 import (
-	"math"
 	"reflect"
 	"testing"
 )
 
 type intSerializationTest struct {
 	Value    interface{}
-	Expected int
+	Expected interface{}
 }
 type float32SerializationTest struct {
 	Value    interface{}
@@ -36,8 +35,8 @@ func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
 		{float32(1e5), 100000}, // Bigger than 2^32, but still representable as an Int
 		{9876504321, 9876504321},
 		{-9876504321, -9876504321},
-		{float64(1e100), math.MinInt64},
-		{float64(-1e100), math.MinInt64},
+		{float64(1e100), nil},
+		{float64(-1e100), nil},
 		{"-1.1", -1},
 		{"one", 0},
 		{false, 0},

--- a/types/scalars_serialization_test.go
+++ b/types/scalars_serialization_test.go
@@ -38,7 +38,7 @@ func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
 		{float64(1e100), nil},
 		{float64(-1e100), nil},
 		{"-1.1", -1},
-		{"one", 0},
+		{"one", nil},
 		{false, 0},
 		{true, 1},
 	}

--- a/types/scalars_serialization_test.go
+++ b/types/scalars_serialization_test.go
@@ -97,7 +97,7 @@ func TestTypeSystem_Scalar_SerializesOutputBoolean(t *testing.T) {
 	tests := []boolSerializationTest{
 		{"true", true},
 		{"false", false},
-		{"string", false},
+		{"string", true},
 		{"", false},
 		{int(1), true},
 		{int(0), false},

--- a/types/scalars_serialization_test.go
+++ b/types/scalars_serialization_test.go
@@ -11,7 +11,7 @@ type intSerializationTest struct {
 }
 type float32SerializationTest struct {
 	Value    interface{}
-	Expected float32
+	Expected interface{}
 }
 
 type stringSerializationTest struct {
@@ -54,23 +54,23 @@ func TestTypeSystem_Scalar_SerializesOutputInt(t *testing.T) {
 
 func TestTypeSystem_Scalar_SerializesOutputFloat(t *testing.T) {
 	tests := []float32SerializationTest{
-		{int(1), 1.0},
-		{int(0), 0.0},
-		{int(-1), -1.0},
-		{float32(0.1), 0.1},
-		{float32(1.1), 1.1},
-		{float32(-1.1), -1.1},
-		{"-1.1", -1.1},
-		{"one", 0.0},
-		{false, 0.0},
-		{true, 1.0},
+		{int(1), float32(1.0)},
+		{int(0), float32(0.0)},
+		{int(-1), float32(-1.0)},
+		{float32(0.1), float32(0.1)},
+		{float32(1.1), float32(1.1)},
+		{float32(-1.1), float32(-1.1)},
+		{"-1.1", float32(-1.1)},
+		{"one", nil},
+		{false, float32(0.0)},
+		{true, float32(1.0)},
 	}
 
-	for _, test := range tests {
+	for i, test := range tests {
 		val := GraphQLFloat.Serialize(test.Value)
 		if val != test.Expected {
 			reflectedValue := reflect.ValueOf(test.Value)
-			t.Fatalf("Failed GraphQLFloat.Serialize(%v(%v)), expected: %v, got %v", reflectedValue.Type(), test.Value, test.Expected, val)
+			t.Fatalf("Failed test #%d - GraphQLFloat.Serialize(%v(%v)), expected: %v, got %v", i, reflectedValue.Type(), test.Value, test.Expected, val)
 		}
 	}
 }

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -1,9 +1,10 @@
 package types_test
 
 import (
+	"testing"
+
 	"github.com/chris-ramon/graphql-go/language/ast"
 	"github.com/chris-ramon/graphql-go/types"
-	"testing"
 )
 
 var someScalarType = types.NewGraphQLScalarType(types.GraphQLScalarTypeConfig{
@@ -435,7 +436,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithMissingFields(t
 		Name: "SomeObject",
 	})
 	_, err := schemaWithFieldType(badObject)
-	expectedError := `SomeObject fields must be an object with field names as keys.`
+	expectedError := `SomeObject fields must be an object with field names as keys or a function which return such an object.`
 	if err == nil || err.Error() != expectedError {
 		t.Fatalf("Expected error: %v, got %v", expectedError, err)
 	}
@@ -461,7 +462,7 @@ func TestTypeSystem_ObjectsMustHaveFields_RejectsAnObjectTypeWithEmptyFields(t *
 		Fields: types.GraphQLFieldConfigMap{},
 	})
 	_, err := schemaWithFieldType(badObject)
-	expectedError := `SomeObject fields must be an object with field names as keys.`
+	expectedError := `SomeObject fields must be an object with field names as keys or a function which return such an object.`
 	if err == nil || err.Error() != expectedError {
 		t.Fatalf("Expected error: %v, got %v", expectedError, err)
 	}

--- a/types/validation_test.go
+++ b/types/validation_test.go
@@ -538,6 +538,34 @@ func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithArrayInte
 		},
 	})
 	_, err := schemaWithFieldType(types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
+		Name: "SomeObject",
+		Interfaces: (types.GraphQLInterfacesThunk)(func() []*types.GraphQLInterfaceType {
+			return []*types.GraphQLInterfaceType{anotherInterfaceType}
+		}),
+		Fields: types.GraphQLFieldConfigMap{
+			"f": &types.GraphQLFieldConfig{
+				Type: types.GraphQLString,
+			},
+		},
+	}))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTypeSystem_ObjectInterfacesMustBeArray_AcceptsAnObjectTypeWithInterfacesAsFunctionReturningAnArray(t *testing.T) {
+	anotherInterfaceType := types.NewGraphQLInterfaceType(types.GraphQLInterfaceTypeConfig{
+		Name: "AnotherInterface",
+		ResolveType: func(value interface{}, info types.GraphQLResolveInfo) *types.GraphQLObjectType {
+			return nil
+		},
+		Fields: types.GraphQLFieldConfigMap{
+			"f": &types.GraphQLFieldConfig{
+				Type: types.GraphQLString,
+			},
+		},
+	})
+	_, err := schemaWithFieldType(types.NewGraphQLObjectType(types.GraphQLObjectTypeConfig{
 		Name:       "SomeObject",
 		Interfaces: []*types.GraphQLInterfaceType{anotherInterfaceType},
 		Fields: types.GraphQLFieldConfigMap{


### PR DESCRIPTION
Built on top of: https://github.com/chris-ramon/graphql-go/pull/12.

- Updates to correct expectations on `types/scalars_serialization_test.go` that matches ones from `graphql-js`.
- Adds `IdentifiesInputTypes` and `IdentifiesOutputTypes` tests.
- Adds `articleField.Name` expectation to `DefinesAQueryOnlySchema` test.
- Makes `GraphQLObjectType.Interfaces` to be `interface{}` type.
- Adds `IncludesInterfacesThunkSubtypesInTheTypeMap` test to `definition_test.go`.
- Updates `defineFieldMap` message error.
- Adds `AcceptsAnInputObjectTypeWithAFieldFunction` test.
- Adds `AcceptsAnInterfaceTypeDefiningResolveTypeWithImplementingTypeDefiningIsTypeOf` test.